### PR TITLE
Support template matching

### DIFF
--- a/lib/common/imageTool.py
+++ b/lib/common/imageTool.py
@@ -207,31 +207,24 @@ class ImageTool(object):
             coord = [(0,0), (w,h)]
             print "WARNING: Incorrect coordinates, using fully image crop"
         else:
-            if coord[0][0] < 0:
-                coord[0] = (0, coord[0][1])
-                print "WARNING: Incorrect coordinates, set origin x coordinate to 0"
-            if coord[0][0] > w:
-                coord[0] = (w, coord[0][1])
-                print "WARNING: Incorrect coordinates, set origin x coordinate to width"
-            if coord[1][0] < 0:
-                coord[1] = (0, coord[1][1])
-                print "WARNING: Incorrect coordinates, set target x coordinate to 0"
-            if coord[1][0] > w:
-                coord[1] = (w, coord[1][1])
-                print "WARNING: Incorrect coordinates, set target x coordinate to width"
-            if coord[0][1] < 0:
-                coord[0] = (coord[0][0], 0)
-                print "WARNING: Incorrect coordinates, set origin y coordinate to 0"
-            if coord[0][1] > h:
-                coord[0] = (coord[0][0], h)
-                print "WARNING: Incorrect coordinates, set origin y coordinate to height"
-            if coord[1][1] < 0:
-                coord[1] = (coord[1][0], 0)
-                print "WARNING: Incorrect coordinates, set target y coordinate to 0"
-            if coord[1][1] > h:
-                coord[1] = (coord[1][0], h)
-                print "WARNING: Incorrect coordinates, set target y coordinate to height"
-        print "Crop image range" + str(coord)
+            for i in range(2):
+                for j in range(2):
+                    new_val = coord[i][j]
+                    if coord[i][j] < 0:
+                        new_val = 0
+                    elif j == 0 and coord[i][j] > w:
+                        new_val = w
+                    elif j == 1 and coord[i][j] > h:
+                        new_val = h
+                    if new_val != coord[i][j]:
+                        new_xy = [coord[i][0], coord[i][1]]
+                        list_index = int(j == 0)
+                        new_xy[list_index] = coord[i][list_index]
+                        new_xy[j] = new_val
+                        coord[i] = tuple(new_xy)
+                        print "WARNING: Incorrect coordinates, set %s %s coordinate to %s" % (
+                        ["origin", "target"][i], str(unichr(120 + j)), str(new_val))
+        print "Crop image range: " + str(coord)
         if coord[0][0] < coord[1][0] and coord[0][1] < coord[1][1]:
             crop_img = img[coord[0][1]:coord[1][1], coord[0][0]:coord[1][0]]
         elif coord[0][0] > coord[1][0] and coord[0][1] > coord[1][1]:

--- a/lib/common/imageTool.py
+++ b/lib/common/imageTool.py
@@ -25,7 +25,7 @@ class ImageTool(object):
         with open(output_fp, "wb") as fh:
             json.dump(data, fh)
 
-    def convert_video_to_images(self, input_video_fp, output_image_dir_path, output_image_name=None, exec_timestamp_list=[], comp_mode=0):
+    def convert_video_to_images(self, input_video_fp, output_image_dir_path, output_image_name=None, exec_timestamp_list=[], comp_mode=False):
         vidcap = cv2.VideoCapture(input_video_fp)
         if hasattr(cv2, 'CAP_PROP_FPS'):
             self.current_fps = vidcap.get(cv2.CAP_PROP_FPS)
@@ -52,11 +52,10 @@ class ImageTool(object):
             os.mkdir(output_image_dir_path)
             while result:
                 str_image_fp = os.path.join(output_image_dir_path, "image_%d.jpg" % img_cnt)
-                if comp_mode and img_cnt >= self.search_range[0]:
+                if (comp_mode and img_cnt >= self.search_range[0]) or \
+                        (img_cnt >= self.search_range[0] and img_cnt <= self.search_range[1]) or \
+                        (img_cnt >= self.search_range[2] and img_cnt <= self.search_range[3]):
                     cv2.imwrite(str_image_fp, image)
-                else:
-                    if (img_cnt >= self.search_range[0] and img_cnt <= self.search_range[1]) or (img_cnt >= self.search_range[2] and img_cnt <= self.search_range[3]):
-                        cv2.imwrite(str_image_fp, image)
                 self.image_list.append({"time_seq": vidcap.get(0), "image_fp": str_image_fp})
                 result, image = vidcap.read()
                 img_cnt += 1
@@ -153,7 +152,7 @@ class ImageTool(object):
                     image_data = self.image_list[img_index]
                     comparing_dct = self.convert_to_dct(image_data['image_fp'])
                     if self.compare_two_images(sample_dct, comparing_dct):
-                        print "Comparing sample file end %s" % time.strftime("%c")
+                        print "Comparing sample %d file end %s" % (sample_index+1,time.strftime("%c"))
                         result_list.append(image_data)
                         m_start_index = img_index
                         break
@@ -166,7 +165,7 @@ class ImageTool(object):
                     if match_val < min_val:
                         min_val = match_val
                         result_list[-1] = image_data
-                print "Comparing sample file end %s" % time.strftime("%c")
+                print "Comparing sample %d file end %s" % (sample_index + 1, time.strftime("%c"))
         print result_list
         return result_list
 

--- a/lib/common/imageTool.py
+++ b/lib/common/imageTool.py
@@ -7,6 +7,7 @@ import argparse
 import shutil
 import numpy as np
 from argparse import ArgumentDefaultsHelpFormatter
+import re
 
 DEFAULT_IMG_DIR_PATH = os.path.join(os.getcwd(), "images")
 DEFAULT_SAMPLE_DIR_PATH = os.path.join(os.getcwd(), "sample")
@@ -24,7 +25,7 @@ class ImageTool(object):
         with open(output_fp, "wb") as fh:
             json.dump(data, fh)
 
-    def convert_video_to_images(self, input_video_fp, output_image_dir_path, output_image_name=None, exec_timestamp_list=[]):
+    def convert_video_to_images(self, input_video_fp, output_image_dir_path, output_image_name=None, exec_timestamp_list=[], comp_mode=0):
         vidcap = cv2.VideoCapture(input_video_fp)
         if hasattr(cv2, 'CAP_PROP_FPS'):
             self.current_fps = vidcap.get(cv2.CAP_PROP_FPS)
@@ -51,8 +52,11 @@ class ImageTool(object):
             os.mkdir(output_image_dir_path)
             while result:
                 str_image_fp = os.path.join(output_image_dir_path, "image_%d.jpg" % img_cnt)
-                if (img_cnt >= self.search_range[0] and img_cnt <= self.search_range[1]) or (img_cnt >= self.search_range[2] and img_cnt <= self.search_range[3]):
+                if comp_mode and img_cnt >= self.search_range[0]:
                     cv2.imwrite(str_image_fp, image)
+                else:
+                    if (img_cnt >= self.search_range[0] and img_cnt <= self.search_range[1]) or (img_cnt >= self.search_range[2] and img_cnt <= self.search_range[3]):
+                        cv2.imwrite(str_image_fp, image)
                 self.image_list.append({"time_seq": vidcap.get(0), "image_fp": str_image_fp})
                 result, image = vidcap.read()
                 img_cnt += 1
@@ -64,9 +68,10 @@ class ImageTool(object):
             self.search_range[2] = 0
         if self.search_range[3] > len(self.image_list):
             self.search_range[3] = len(self.image_list)
+        print "Image Comparison search range: " + str(self.search_range)
         return self.image_list
 
-    def compare_with_sample_image(self, input_sample_dp, exec_timestamp_list):
+    def compare_with_sample_image(self, input_sample_dp):
         result_list = []
         print "Comparing sample file start %s" % time.strftime("%c")
         sample_fn_list = os.listdir(input_sample_dp)
@@ -124,6 +129,121 @@ class ImageTool(object):
         dct_obj = cv2.dct(img_dct)
         return dct_obj
 
+    def atoi(self, text):
+        return int(text) if text.isdigit() else text
+
+    def natural_keys(self, text):
+        return [self.atoi(c) for c in re.split('(\d+)', text)]
+
+    def compare_with_sample_object(self, input_sample_dp):
+        result_list = []
+        m_start_index = 0
+        print "Comparing sample file start %s" % time.strftime("%c")
+        sample_fn_list = os.listdir(input_sample_dp)
+        if len(sample_fn_list) <= 2:
+            return result_list
+        sample_fn_list.sort(key=self.natural_keys)
+        for sample_index in range(0, len(sample_fn_list)):
+            sample_fp = os.path.join(input_sample_dp, sample_fn_list[sample_index])
+            if sample_index == 1:
+                print "Template matching will skip the second sample's comparison"
+            elif sample_index == 0:
+                sample_dct = self.convert_to_dct(sample_fp)
+                for img_index in range(self.search_range[1] - 1, self.search_range[0], -1):
+                    image_data = self.image_list[img_index]
+                    comparing_dct = self.convert_to_dct(image_data['image_fp'])
+                    if self.compare_two_images(sample_dct, comparing_dct):
+                        print "Comparing sample file end %s" % time.strftime("%c")
+                        result_list.append(image_data)
+                        m_start_index = img_index
+                        break
+            else:
+                min_val = 1.0
+                result_list.append(self.image_list[m_start_index])
+                for img_index in range(m_start_index, self.search_range[3]):
+                    image_data = self.image_list[img_index]
+                    match_val = self.template_match(image_data['image_fp'], sample_fp)
+                    if match_val < min_val:
+                        min_val = match_val
+                        result_list[-1] = image_data
+                print "Comparing sample file end %s" % time.strftime("%c")
+        print result_list
+        return result_list
+
+    def template_match(self, base_img_fp, template_fp):
+        img = cv2.imread(base_img_fp)
+        img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        template = cv2.imread(template_fp, 0)
+        w, h = template.shape[::-1]
+
+        #Choose SQDIFF_NORMED method to perform template matching
+        methods = 'cv2.TM_SQDIFF_NORMED'
+        method_eval = eval(methods)
+
+        # Apply template Matching
+        res = cv2.matchTemplate(img_gray, template, method_eval)
+        min_val, max_val, min_loc, max_loc = cv2.minMaxLoc(res)
+
+        #For artifactual image output
+        '''
+        str_image_fp = $TBD
+        #Draw a rectangle on the target object
+        top_left = min_loc
+        bottom_right = (top_left[0] + w, top_left[1] + h)
+        cv2.imwrite(str_image_fp, cv2.rectangle(img, top_left, bottom_right, (0, 0, 255), 2))
+
+        #cv2.imshow('original', img)
+        #cv2.waitKey(0)
+        '''
+        return min_val
+
+    def crop_image(self, input_sample_fp, output_sample_fp, coord=[]):
+        img = cv2.imread(input_sample_fp)
+        img_gray = cv2.cvtColor(img, cv2.COLOR_BGR2GRAY)
+        w, h = img_gray.shape[::-1]
+        if not coord or len(coord) != 2 or \
+                        type(coord[0]) is not tuple or len(coord[0]) !=2 or \
+                        type(coord[1]) is not tuple or len(coord[1]) !=2 :
+            coord = [(0,0), (w,h)]
+            print "WARNING: Incorrect coordinates, using fully image crop"
+        else:
+            if coord[0][0] < 0:
+                coord[0] = (0, coord[0][1])
+                print "WARNING: Incorrect coordinates, set origin x coordinate to 0"
+            if coord[0][0] > w:
+                coord[0] = (w, coord[0][1])
+                print "WARNING: Incorrect coordinates, set origin x coordinate to width"
+            if coord[1][0] < 0:
+                coord[1] = (0, coord[1][1])
+                print "WARNING: Incorrect coordinates, set target x coordinate to 0"
+            if coord[1][0] > w:
+                coord[1] = (w, coord[1][1])
+                print "WARNING: Incorrect coordinates, set target x coordinate to width"
+            if coord[0][1] < 0:
+                coord[0] = (coord[0][0], 0)
+                print "WARNING: Incorrect coordinates, set origin y coordinate to 0"
+            if coord[0][1] > h:
+                coord[0] = (coord[0][0], h)
+                print "WARNING: Incorrect coordinates, set origin y coordinate to height"
+            if coord[1][1] < 0:
+                coord[1] = (coord[1][0], 0)
+                print "WARNING: Incorrect coordinates, set target y coordinate to 0"
+            if coord[1][1] > h:
+                coord[1] = (coord[1][0], h)
+                print "WARNING: Incorrect coordinates, set target y coordinate to height"
+        print "Crop image range" + str(coord)
+        if coord[0][0] < coord[1][0] and coord[0][1] < coord[1][1]:
+            crop_img = img[coord[0][1]:coord[1][1], coord[0][0]:coord[1][0]]
+        elif coord[0][0] > coord[1][0] and coord[0][1] > coord[1][1]:
+            crop_img = img[coord[1][1]:coord[0][1], coord[1][0]:coord[0][0]]
+        elif coord[0][0] < coord[1][0] and coord[0][1] > coord[1][1]:
+            crop_img = img[coord[1][1]:coord[0][1], coord[0][0]:coord[1][0]]
+        else:
+            crop_img = img[coord[0][1]:coord[1][1], coord[1][0]:coord[0][0]]
+        cv2.imwrite(output_sample_fp, crop_img)
+        return output_sample_fp
+
+
 def main():
     arg_parser = argparse.ArgumentParser(description='Image tool',
                                          formatter_class=ArgumentDefaultsHelpFormatter)
@@ -131,8 +251,10 @@ def main():
                             help='convert video to images.', required=False)
     arg_parser.add_argument('--compareimg', action='store_true', dest='compare_img_flag', default=False,
                             help='compare images.', required=False)
+    arg_parser.add_argument('--cropimg', action='store_true', dest='crop_img_flag', default=False,
+                            help='crop image', required=False)
     arg_parser.add_argument('-i', '--input', action='store', dest='input_video_fp', default=None,
-                            help='Specify the video file path.', required=False)
+                            help='Specify the file path.', required=False)
     arg_parser.add_argument('-o', '--outputdir', action='store', dest='output_img_dp', default=None,
                             help='Specify output image dir path.', required=False)
     arg_parser.add_argument('-n', '--outputimgname', action='store', dest='output_img_name', default=None,
@@ -150,7 +272,14 @@ def main():
     sample_img_dp = args.sample_img_dp
     result_fp = args.result_fp
 
-    if args.convert_video_flag is False and args.compare_img_flag is False:
+    if args.crop_img_flag:
+        if input_video_fp and output_img_dp and output_img_name:
+            if not os.path.exists(output_img_dp):
+                os.mkdir(output_img_dp)
+            img_tool_obj.crop_image(input_video_fp, os.path.join(output_img_dp,output_img_name))
+        else:
+            print "Please specify the sample image file path, output image dir path, and output image name."
+    elif args.convert_video_flag is False and args.compare_img_flag is False:
         # default is compare images
         if input_video_fp and output_img_dp and sample_img_dp and result_fp:
             img_tool_obj.convert_video_to_images(input_video_fp, output_img_dp, output_img_name)

--- a/lib/helper/resultHelper.py
+++ b/lib/helper/resultHelper.py
@@ -10,7 +10,7 @@ def run_image_analyze(input_video_fp, output_img_dp, input_sample_dp, exec_times
         os.mkdir(output_img_dp)
     img_tool_obj = ImageTool()
     img_tool_obj.convert_video_to_images(input_video_fp, output_img_dp, None, exec_timestamp_list)
-    return img_tool_obj.compare_with_sample_image(input_sample_dp, exec_timestamp_list)
+    return img_tool_obj.compare_with_sample_image(input_sample_dp)
 
 
 def output_result(test_method_name,current_run_result, output_fp, time_list_counter_fp, test_method_doc, outlier_check_point):


### PR DESCRIPTION
1.remove redundant interface from compare_with_sample_image in imageTool
2.support template matching
  - crop_image supports to crop an image according to tuple list of range, e.g. [(x1,y1), (x2,y2)]
  - template_match calculates comparison results between image and template to find out the most similarity area
  - compare_with_sample_object wraps image list and sample images to compare and find out target results
  - atoi and natural_keys support to get correct result of sorted image sequence names which contain digits