### PR TITLE
Fix the issue of PyDrive (oauth2client).

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 theano==0.8.2
 numpy>=1.10.0
 psutil>=4.1.0
+oauth2client==3.0.0
+google-api-python-client==1.5.3
 PyDrive==1.0.1
 pyperclip>=1.5.27
 web.py>=0.38


### PR DESCRIPTION
https://travis-ci.org/Mozilla-TWQA/Hasal/jobs/168502877
Ref:
Traceback (most recent call last):
  File "runtest.py", line 27, in <module>
    from lib.helper.uploadAgentHelper import UploadAgent
  File "/home/travis/build/Mozilla-TWQA/Hasal/lib/helper/uploadAgentHelper.py", line 10, in <module>
    from ..common.pyDriveUtil import PyDriveUtil
  File "/home/travis/build/Mozilla-TWQA/Hasal/lib/common/pyDriveUtil.py", line 2, in <module>
    from pydrive.auth import GoogleAuth
  File "/home/travis/build/Mozilla-TWQA/Hasal/.env-python/local/lib/python2.7/site-packages/pydrive/auth.py", line 13, in <module>
    from oauth2client.file import CredentialsFileSymbolicLinkError
ImportError: cannot import name CredentialsFileSymbolicLinkError