### PR TITLE
Add apt-get update before install packages.

### DIFF
--- a/bootstrap-linux.sh
+++ b/bootstrap-linux.sh
@@ -73,6 +73,9 @@ func_log "[PASS] Checking finished."
 # Installation #
 ################
 
+func_log "[INFO] Running apt-get update ..."
+sudo apt-get update
+
 func_log "[INFO] Install Requirements ..."
 
 # tools


### PR DESCRIPTION
- there are some packages cannot be found before apt-get update
- ex: if cannot found libssl-dev, it will cause following issue:
```
warning: no previously-included files matching '*' found under directory 'vectors'
build/temp.linux-x86_64-2.7/_openssl.c:433:30: fatal error: openssl/opensslv.h: No such file or directory
 #include <openssl/opensslv.h>
                               ^
compilation terminated.
error: Setup script exited with error: command 'x86_64-linux-gnu-gcc' failed with exit status 1
```