### PR TITLE
Add command in bootstrap-linux for disable Unity Web App Integration

### DIFF
--- a/bootstrap-linux.sh
+++ b/bootstrap-linux.sh
@@ -164,6 +164,9 @@ echo ""
 if [[ ${TRAVIS} ]]; then
     func_log "[WARN] Skip checking browsers."
 else
+    func_log "[INFO] Disable the Unity Web App Integration Prompt."
+    gsettings set com.canonical.unity.webapps integration-allowed false
+
     func_log "[INFO] Checking browsers ..."
 
     which firefox > /dev/null


### PR DESCRIPTION
- fix #390

Ref:
http://askubuntu.com/questions/214755/how-can-i-remove-unity-web-apps