### PR TITLE
Fix the error of brew and sys_pkg_checker on Mac

### DIFF
--- a/bootstrap-mac.sh
+++ b/bootstrap-mac.sh
@@ -163,11 +163,6 @@ func_log_exec ./scripts/sys_pkg_checker.py
 ./scripts/sys_pkg_checker.py
 CHECK_SYS_RET=$?
 
-func_log "[INFO] Checking mitmproxy ..."
-mitmdump -h
-CHECK_PROXY_RET=$?
-echo "Return code:" ${CHECK_PROXY_RET}
-
 ###########
 # Browser #
 ###########

--- a/bootstrap-mac.sh
+++ b/bootstrap-mac.sh
@@ -97,7 +97,7 @@ brew install wget
 if [[ ${TRAVIS} ]]; then
     func_log "[WARN] Skip installing ffmpeg on Travis CI, due to it is very slow!"
     func_log "[INFO] Installing opencv without ffmpeg (on Travis CI) ..."
-    brew install homebrew/science/opencv
+    brew install homebrew/science/opencv || brew link --overwrite homebrew/python/numpy
 else
     func_log "[INFO] Installing ffmpeg ..."
     brew install ffmpeg --with-fdk-aac --with-ffplay --with-freetype --with-frei0r --with-libass --with-libvo-aacenc --with-libvorbis --with-libvpx --with-opencore-amr --with-openjpeg --with-opus --with-rtmpdump --with-schroedinger --with-speex --with-theora --with-tools
@@ -162,6 +162,11 @@ func_log "[INFO] Checking System Packages ..."
 func_log_exec ./scripts/sys_pkg_checker.py
 ./scripts/sys_pkg_checker.py
 CHECK_SYS_RET=$?
+
+func_log "[INFO] Checking mitmproxy ..."
+mitmdump -h
+CHECK_PROXY_RET=$?
+echo "Return code:" ${CHECK_PROXY_RET}
 
 ###########
 # Browser #

--- a/scripts/sys_pkg_checker.py
+++ b/scripts/sys_pkg_checker.py
@@ -75,10 +75,9 @@ class SysPkgChecker(object):
                 print('Skip, current platform is {}, not {}'.format(self.current_platform, platform), end='\n')
                 continue
             else:
-                with open(os.devnull) as fp:
+                with open(os.devnull, 'w') as fp:
                     try:
-                        #ret_code = subprocess.call(cmd, stdout=fp, stderr=fp)
-                        ret_code = subprocess.call(cmd)
+                        ret_code = subprocess.call(cmd, stdout=fp, stderr=fp)
                         if ret_code == SysPkgChecker._CMD_SUCCESS:
                             print('OK', end='\n')
                         else:

--- a/scripts/sys_pkg_checker.py
+++ b/scripts/sys_pkg_checker.py
@@ -77,13 +77,15 @@ class SysPkgChecker(object):
             else:
                 with open(os.devnull) as fp:
                     try:
-                        ret_code = subprocess.call(cmd, stdout=fp, stderr=fp)
+                        #ret_code = subprocess.call(cmd, stdout=fp, stderr=fp)
+                        ret_code = subprocess.call(cmd)
                         if ret_code == SysPkgChecker._CMD_SUCCESS:
                             print('OK', end='\n')
                         else:
-                            print('Fail', end='\n')
+                            print('Fail, return code {}'.format(ret_code), end='\n')
                             error_pkg_list.append(pkg_name)
-                    except Exception:
+                    except Exception as e:
+                        print(e)
                         print('Fail', end='\n')
                         error_pkg_list.append(pkg_name)
         return error_pkg_list


### PR DESCRIPTION
Found error message from Travis CI https://travis-ci.org/Mozilla-TWQA/Hasal/jobs/186902114
```
[INFO] Installing opencv without ffmpeg (on Travis CI) ...
==> Installing opencv from homebrew/science
==> Tapping homebrew/python
Cloning into '/usr/local/Homebrew/Library/Taps/homebrew/homebrew-python'...
remote: Counting objects: 24, done.
remote: Compressing objects: 100% (24/24), done.
remote: Total 24 (delta 1), reused 6 (delta 0), pack-reused 0
Unpacking objects: 100% (24/24), done.
Tapped 20 formulae (68 files, 102K)
==> Installing dependencies for homebrew/science/opencv: libpng, libtiff, eigen, ilmbase, openexr, homebrew/python/numpy
...
==> Installing homebrew/science/opencv dependency: homebrew/python/numpy
==> Downloading https://homebrew.bintray.com/bottles-python/numpy-1.11.2.el_capi
==> Pouring numpy-1.11.2.el_capitan.bottle.tar.gz
Error: The `brew link` step did not complete successfully
The formula built, but is not symlinked into /usr/local
Could not symlink bin/f2py
Target /usr/local/bin/f2py
already exists. You may want to remove it:
  rm '/usr/local/bin/f2py'
To force the link and overwrite all conflicting files:
  brew link --overwrite numpy
To list all files that would be deleted:
  brew link --overwrite --dry-run numpy
Possible conflicting files are:
/usr/local/bin/f2py
/usr/local/lib/python2.7/site-packages/numpy/__config__.py
...
/usr/local/lib/python2.7/site-packages/numpy/version.py
==> Caveats
If you use system python (that comes - depending on the OS X version -
with older versions of numpy, scipy and matplotlib), you may need to
ensure that the brewed packages come earlier in Python's sys.path with:
  mkdir -p /Users/travis/Library/Python/2.7/lib/python/site-packages
  echo 'import sys; sys.path.insert(1, "/usr/local/lib/python2.7/site-packages")' >> /Users/travis/Library/Python/2.7/lib/python/site-packages/homebrew.pth
==> Summary
🍺  /usr/local/Cellar/numpy/1.11.2: 433 files, 9M
```

Also, found 2nd error from https://travis-ci.org/Mozilla-TWQA/Hasal/jobs/186912656
```
[INFO] The environment variable "TRAVIS" is True, enable CI mode.
[INFO] Check ffmpeg ... CI Skip
[INFO] Check libav-tools ... OK
[INFO] Check imagemagick ... OK
[INFO] Check imagemagick ... OK
[INFO] Check mitmproxy ... Fail, return code 120
[INFO] Check sikulix ... CI Skip
[Error] Some system packages failed.
	mitmproxy
```
