### PR TITLE
Remove win32gui.SetForegroundWindow

### DIFF
--- a/lib/common/windowController.py
+++ b/lib/common/windowController.py
@@ -66,8 +66,6 @@ class WindowObject(object):
             # move position
             win32gui.SetWindowPos(hwnd, win32con.HWND_TOP, self.pos_x, self.pos_y, self.window_width,
                                   self.window_height, 0)
-            # move to foreground
-            win32gui.SetForegroundWindow(hwnd)
             self.callback_ret = True
 
     def pywin32_move_window(self):


### PR DESCRIPTION
Line 67 `win32con.HWND_TOP` will bring window to top.

Fix following issue:
```
2016-12-30 00:29:53,009 runtest.py   DEBUG    ========== Environment data ======
2016-12-30 00:29:53,009 runtest.py   INFO     python -m unittest tests.regression.gdoc.test_firefox_gdoc_read_basic_table_1
2016-12-30 00:29:55,359 lib.browser.base DEBUG    browser launch command:['firefox', '-height', '980', '-width', '1200']
2016-12-30 00:30:06,052 lib.common.windowController WARNING  Cannot found [Mozilla Firefox] for moving position.
E
======================================================================
ERROR: test_firefox_gdoc_read_basic_table_1 (tests.regression.gdoc.test_firefox_gdoc_read_basic_table_1.TestSikuli)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "tests\regression\gdoc\test_firefox_gdoc_read_basic_table_1.py", line 8, in setUp
    super(TestSikuli, self).setUp()
  File "lib\perfBaseTest.py", line 130, in setUp
    desktopHelper.lock_window_pos(self.browser_type)
  File "lib\helper\desktopHelper.py", line 92, in lock_window_pos
    if window_obj.move_window_pos(0, 0, DEFAULT_BROWSER_WIDTH, DEFAULT_BROWSER_HEIGHT):
  File "lib\common\windowController.py", line 117, in move_window_pos
    return self.pywin32_move_window()
  File "lib\common\windowController.py", line 76, in pywin32_move_window
    win32gui.EnumWindows(self.pywin32_callback_func, None)
  File "lib\common\windowController.py", line 70, in pywin32_callback_func
    win32gui.SetForegroundWindow(hwnd)
error: (18, 'SetForegroundWindow', '\xa8S\xa6\xb3\xa8\xe4\xa5L\xc0\xc9\xae\xd7\xa1C')

----------------------------------------------------------------------
Ran 1 test in 11.295s

FAILED (errors=1)
```