### PR TITLE
Remove the asc file from match file list

### DIFF
--- a/tools/trigger_build.py
+++ b/tools/trigger_build.py
@@ -266,7 +266,8 @@ class TriggerBuild(object):
                 return False
             else:
                 matched_keyword = self.PLATFORM_FN_MAPPING[self.platform]['key'] + "." + self.PLATFORM_FN_MAPPING[self.platform]['ext']
-                matched_file_list = [fn for fn in remote_file_dict.keys() if matched_keyword in fn and "firefox" in fn]
+                matched_file_list = [fn for fn in remote_file_dict.keys()
+                                     if ((matched_keyword in fn) and ('firefox' in fn) and (not fn.endswith('.asc')))]
                 if len(matched_file_list) != 1:
                     print "WARN: the possible match file list is not equal 1, list as below: [%s]" % matched_file_list
                     if len(matched_file_list) < 1:


### PR DESCRIPTION
Ref:
12:08:05 WARN: the possible match file list is not equal 1, list as below: [['firefox-53.0a1.en-US.linux-x86_64.tar.bz2', 'firefox-53.0a1.en-US.linux-x86_64.tar.bz2.asc']]
12:08:05 WARN: select following file [['firefox-53.0a1.en-US.linux-x86_64.tar.bz2.asc']]
12:08:05 ERROR: can't find the json file[firefox-53.0a1.en-US.linux-x86_64.json.asc] in remote file list