### PR TITLE
Fix the issue of cv2.VideoCapture is not opened

### DIFF
--- a/lib/common/imageTool.py
+++ b/lib/common/imageTool.py
@@ -65,6 +65,18 @@ class ImageTool(object):
 
     def convert_video_to_images(self, input_video_fp, output_image_dir_path, output_image_name=None, exec_timestamp_list=[]):
         vidcap = cv2.VideoCapture(input_video_fp)
+        # make sure the video file is opened, ready for convert to images
+        for _ in range(60):
+            if vidcap.isOpened():
+                break
+            else:
+                time.sleep(1)
+                vidcap = cv2.VideoCapture(input_video_fp)
+        if not vidcap.isOpened():
+            logger.debug('Video file cannot open: {}'.format(input_video_fp))
+            return None
+        logger.debug('Video file is opened: {}'.format(input_video_fp))
+
         if hasattr(cv2, 'CAP_PROP_FPS'):
             header_fps = vidcap.get(cv2.CAP_PROP_FPS)
         else:


### PR DESCRIPTION
ref:
The `vidcap.isOpened()` is `False` if Video file is not ready.
And the `result, image` will be `Fasle, None`.
```
vidcap = cv2.VideoCapture(input_video_fp)
result, image = vidcap.read()
```