### PR TITLE
Support moving Terminal window for  Windows 7 and 10

### DIFF
--- a/lib/baseTest.py
+++ b/lib/baseTest.py
@@ -84,7 +84,7 @@ class BaseTest(unittest.TestCase):
                             release_version = platform.release()
                             if release_version == '10':
                                 logger.info("Move terminal window for Windows 10.")
-                                height_offset = 0
+                                height_offset = -4
                                 terminal_height = 100
                             elif release_version == '7':
                                 logger.info("Move terminal window for Windows 7.")

--- a/lib/baseTest.py
+++ b/lib/baseTest.py
@@ -80,8 +80,20 @@ class BaseTest(unittest.TestCase):
                             height_offset = 20
                             terminal_height = 60
                         elif sys.platform == 'win32':
-                            height_offset = 0
-                            terminal_height = 70
+                            import platform
+                            release_version = platform.release()
+                            if release_version == '10':
+                                logger.info("Move terminal window for Windows 10.")
+                                height_offset = 0
+                                terminal_height = 100
+                            elif release_version == '7':
+                                logger.info("Move terminal window for Windows 7.")
+                                height_offset = 0
+                                terminal_height = 80
+                            else:
+                                logger.info("Move terminal window for Windows.")
+                                height_offset = 0
+                                terminal_height = 80
                         elif sys.platform == 'darwin':
                             # TODO: This offset settings only be tested on Mac Book Air
                             height_offset = 115


### PR DESCRIPTION
The offset and height of Terminal window are different on Window 7 and Windows 10.
