### PR TITLE
rename sikuli_status to round_status

### DIFF
--- a/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gdoc_ail_pagedown_10_text(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gdoc_ail_pagedown_10_text(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gdoc_ail_type_0(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gdoc_ail_type_0(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gdoc_ail_type_10p_txt(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gdoc_ail_type_10p_txt(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gdoc_ail_pagedown_10_text(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gdoc_ail_pagedown_10_text(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gdoc_ail_type_0(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gdoc_ail_type_0(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gdoc_ail_type_10p_txt(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gdoc_ail_type_10p_txt(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gsheet_ail_pagedown_400_text(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gsheet_ail_pagedown_400_text(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gsheet_ail_type_0(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gsheet_ail_type_0(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_chrome_gsheet_ail_type_400(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_chrome_gsheet_ail_type_400(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gsheet_ail_pagedown_400_text(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gsheet_ail_pagedown_400_text(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gsheet_ail_type_0(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gsheet_ail_type_0(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.py
@@ -8,7 +8,7 @@ class TestSikuli(PerfBaseTest):
         super(TestSikuli, self).setUp()
 
     def test_firefox_gsheet_ail_type_400(self):
-        self.sikuli_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
+        self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
                                                   script_dp=self.env.test_script_py_dp,
                                                   args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
                                                              self.env.DEFAULT_VIDEO_RECORDING_WIDTH,

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.py
@@ -9,8 +9,8 @@ class TestSikuli(PerfBaseTest):
 
     def test_firefox_gsheet_ail_type_400(self):
         self.round_status = self.sikuli.run_test(self.env.test_name, self.env.output_name, test_target=self.test_url,
-                                                  script_dp=self.env.test_script_py_dp,
-                                                  args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
-                                                             self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
-                                                             self.env.DEFAULT_TIMESTAMP])
+                                                 script_dp=self.env.test_script_py_dp,
+                                                 args_list=[self.env.img_sample_dp, self.env.img_output_sample_1_fn,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_WIDTH,
+                                                            self.env.DEFAULT_VIDEO_RECORDING_HEIGHT,
+                                                            self.env.DEFAULT_TIMESTAMP])


### PR DESCRIPTION
sikuli_status was out-of-date.
The historic reason for this change is from #551 .
We no longer only support webdriver so we change the sikuli_status to round_status as a result.

Please do use round_status as returned status next time.

@ShakoHo @askeing  r?
