### PR TITLE
Modified logging message formatter

### DIFF
--- a/lib/common/logConfig.py
+++ b/lib/common/logConfig.py
@@ -4,7 +4,7 @@ import logging
 def get_logger(name, enable_advance=None):
     logger = logging.getLogger(name)
     handler = logging.StreamHandler()
-    formatter = logging.Formatter('%(asctime)s %(name)-12s %(levelname)-8s %(message)s')
+    formatter = logging.Formatter('%(asctime)s %(levelname)s [%(name)s.%(funcName)s] %(message)s', datefmt='%Y-%m-%d %H:%M')
     handler.setFormatter(formatter)
     logger.addHandler(handler)
     if enable_advance:


### PR DESCRIPTION
Today, I found sometimes when we get the error message, we cannot identify which method the message comes from.
Adding the method name into logging message might help us to find the correct method.

@ShakoHo @MikeLien @ypwalter r?

Origin:
```log
2017-04-14 16:59:45.980 lib.helper.firefoxProfileCreator INFO XXX set to be disabled.
2017-04-14 16:59:45.980 runtest.py INFO The counter is 0 and the retry counter is 0
```

New:
```log
2017-04-14 16:59 INFO [lib.helper.firefoxProfileCreator._install_profile_extensions] XXX set to be disabled.
2017-04-14 16:59 INFO [runtest.py.loop_test] The counter is 0 and the retry counter is 0
```
