### PR TITLE
Modified the requirements of Hasal framework and tools

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -222,7 +222,7 @@ IF "%APPVEYOR%"=="True" (
 conda config --set always_yes yes --set changeps1 no
 conda install psutil
 ECHO [INFO] Creating Miniconda virtualenv (It might take some time to finish.)
-conda create -q -n env-python python=2.7 numpy scipy nose pywin32 pip matplotlib==1.5.3 runipy==0.1.5
+conda create -q -n env-python python=2.7 numpy scipy nose pywin32 pip
 
 ::::::::::::::::::::
 ::    Browsers    ::

--- a/bootstrap.ps1
+++ b/bootstrap.ps1
@@ -169,7 +169,7 @@ If ($lastexitcode -notmatch 0) {
 "[INFO] Creating Miniconda virtualenv (It might take some time to finish.)"
 conda config --set always_yes yes --set changeps1 no
 conda install psutil
-conda create -q -n env-python python=2.7 numpy scipy nose pywin32 pip matplotlib==1.5.3 runipy==0.1.5
+conda create -q -n env-python python=2.7 numpy scipy nose pywin32 pip
 
 Copy-Item C:\ProgramData\chocolatey\lib\sikulix\content\* .\thirdParty\
 Copy-Item .\scripts\runsikuli* .\thirdParty\

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,9 +13,6 @@ argparse==1.2.1
 watchdog==0.8.3
 peakutils==1.0.3
 treeherder-client==3.1.0
-matplotlib==1.5.3
-pandas>=0.19.2
-runipy==0.1.5
 selenium==3.0.2
 geckoprofiler_controller==0.0.4
 

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,6 +2,18 @@
 
 Hasal Tools.
 
+Please run following command for installing tools' requirements after activating virtualenv.
+
+**Linux/Mac**
+
+`pip install -r tools/requirements.txt`
+
+or
+
+**Windows**
+
+`conda install --file tools\requirements.txt`
+
 ## parse\_hasal\_result
 
 ### Prepare
@@ -9,8 +21,8 @@ Hasal Tools.
 Setup the env:
 ```bash
 $ make clean dev-env
-$ source ~/.hasalenv/bin/activate
-(.hasalenv)$
+$ source ~/.env-python/bin/activate
+(.env-python)$
 ```
 
 Then running tests. There is the `result.json` file when tests finished.

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,3 +1,6 @@
 treeherder-client==3.1.0
 docopt==0.6.2
 tqdm==4.8.4
+matplotlib==1.5.3
+pandas>=0.19.2
+runipy==0.1.5


### PR DESCRIPTION
The `matplotlib==1.5.3`, `pandas>=0.19.2`, and `runipy==0.1.5` are not required packages of Hasal platform, they are `tools`' requirements.

ref: #597