### PR TITLE
Remove Sikulix setAutoWaitTimeout() in common library

### DIFF
--- a/lib/sikuli/facebook.sikuli/facebook.py
+++ b/lib/sikuli/facebook.sikuli/facebook.py
@@ -48,22 +48,13 @@ class facebook():
         self.sampleImg1 = os.path.join(os.path.dirname(os.path.realpath(__file__)), "content", "sample_1.jpg")
 
     def wait_for_loaded(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
-        wait(self.fb_logo)
-        setAutoWaitTimeout(default_timeout)
+        wait(self.fb_logo, 15)
 
     def wait_for_messenger_loaded(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
-        wait(self.messenger_header)
-        setAutoWaitTimeout(default_timeout)
+        wait(self.messenger_header, 15)
 
     def focus_window(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
-        click(self.fb_logo.targetOffset(0, 15))
-        setAutoWaitTimeout(default_timeout)
+        click(self.fb_logo.targetOffset(0, 15), 10)
 
     def post_content(self, location=None, content_type=None, input_string=None):
         if not location or not input_string or not content_type:

--- a/lib/sikuli/gdoc.sikuli/gdoc.py
+++ b/lib/sikuli/gdoc.sikuli/gdoc.py
@@ -14,20 +14,14 @@ class gDoc():
             self.alt = Key.ALT
 
     def wait_for_loaded(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
         wait(Pattern("pics/gdoc.png").similar(0.85), 60)
         wait(3)
-        setAutoWaitTimeout(default_timeout)
         self.focus_content()
 
     def focus_content(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
         wait(Pattern("pics/printer.png").similar(0.60), 60)
         click(Pattern("pics/printer.png").similar(0.60).targetOffset(50, 60))
         wait(3)
-        setAutoWaitTimeout(default_timeout)
 
     # Prevent cursor twinkling on screen
     def deFoucsContentWindow(self):

--- a/lib/sikuli/gsheet.sikuli/gsheet.py
+++ b/lib/sikuli/gsheet.sikuli/gsheet.py
@@ -22,10 +22,7 @@ class gSheet():
         self.gsheet_1st_cell = Pattern("pics/column_header.png").similar(0.70).targetOffset(0, 80)
 
     def wait_for_loaded(self):
-        default_timeout = getAutoWaitTimeout()
-        setAutoWaitTimeout(10)
-        wait(self.gsheet_tab_icon)
-        setAutoWaitTimeout(default_timeout)
+        wait(self.gsheet_tab_icon, 10)
 
     def modify_highlight_cell(self, input_txt):
         click(self.gsheet_modify_highlight_cell)


### PR DESCRIPTION
@askeing @MikeLien @ShakoHo r?

According to the sikulix documentation, `wait(element, time)` is exactly what `setAutoWaitTimeout(time);wait(element);` does.

Reference: http://doc.sikuli.org/region.html#Region.wait
> seconds – a number, which can have a fraction, as maximum waiting time in seconds. The internal granularity is milliseconds. If not specified, the auto wait timeout value set by Region.setAutoWaitTimeout() is used. Use the constant FOREVER to wait for an infinite time.

However, there are still more `setAutoWaitTimeout()` in pilot or regression test cases. I think we should consider a more elegant way to handle them when we create new cases and when we have to modify the test cases. The code should be like what I did in this pr.