### PR TITLE
Support getting current Username, and fixing the username issue of obsProfiler

### DIFF
--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -8,6 +8,8 @@ from datetime import datetime
 from environment import Environment
 from logConfig import get_logger
 
+logger = get_logger(__name__)
+
 
 class StatusRecorder(object):
     # Result for STATUS_IMG_COMPARE_RESULT
@@ -260,6 +262,60 @@ class CommonUtil(object):
 
     RECORDER_LIST = [Environment.PROFILER_FLAG_AVCONV, Environment.PROFILER_FLAG_OBS]
     logger = get_logger(__file__)
+
+    @staticmethod
+    def get_username():
+        """
+        Get current username.
+        The UNIX platform will return the value of `pwd.getpwuid(os.getuid()).pw_name`.
+        The Windows platform will return 'USERNAME' of environ, or default username `user`.
+        @return: current username.
+        """
+        if platform.system().lower() == 'windows':
+            username = os.environ.get('USERNAME')
+            if not username:
+                # default user name
+                username = 'user'
+        else:
+            import pwd
+            username = pwd.getpwuid(os.getuid()).pw_name
+        return username
+
+    @staticmethod
+    def get_appdata_dir():
+        """
+        Get current user's AppData folder.
+
+        Availability: Windows.
+        @return: current user's AppData folder.
+        """
+        if platform.system().lower() == 'windows':
+            appdata_path = os.environ.get('APPDATA')
+            if not appdata_path:
+                # default user APPDATA folder
+                appdata_path = r'C:\Users\{username}\AppData\Roaming'.format(username=CommonUtil.get_username())
+        else:
+            logger.error('Doesn\'t support get APPDATA at platform {}.'.format(platform.system()))
+            appdata_path = ''
+        return appdata_path
+
+    @staticmethod
+    def get_user_dir():
+        """
+        Get current user's home folder.
+        The UNIX platform will return the value of `pwd.getpwuid(os.getuid()).pw_dir`.
+        The Windows platform will return 'USERPROFILE' of environ.
+        @return: current user's home folder.
+        """
+        if platform.system().lower() == 'windows':
+            user_dir = os.environ.get('USERPROFILE')
+            if not user_dir:
+                # default user dir
+                user_dir = r'C:\Users\{username}'.format(username=CommonUtil.get_username())
+        else:
+            import pwd
+            user_dir = pwd.getpwuid(os.getuid()).pw_dir
+        return user_dir
 
     @staticmethod
     def execute_runipy_cmd(input_template_fp, output_ipynb_fp, **kwargs):

--- a/lib/profiler/obsProfiler.py
+++ b/lib/profiler/obsProfiler.py
@@ -25,16 +25,17 @@ class ObsProfiler(BaseProfiler):
     please download and install Visual C++ Redistributable Packages for Visual Studio 2013 from
     https://www.microsoft.com/en-us/download/details.aspx?id=40784
     """
-    OBS_SETTINGS_DIR_PATH = r'C:\Users\user\AppData\Roaming\obs-studio'
+    OBS_SETTINGS_DIR_PATH = os.path.join(CommonUtil.get_appdata_dir(), 'obs-studio')
     OBS_SETTINGS_FN = 'global.ini'
 
     OBS_COLLECTION_TEMPLATE_PATH = os.path.join(os.getcwd(), 'thirdparty', 'obsConfigs', 'collection')
-    OBS_COLLECTION_DIR_PATH = r'C:\Users\user\AppData\Roaming\obs-studio\basic\scenes'
+    OBS_COLLECTION_DIR_PATH = os.path.join(CommonUtil.get_appdata_dir(), 'obs-studio', 'basic', 'scenes')
     OBS_COLLECTION_NAME = 'hasal'
     OBS_COLLECTION_FN = OBS_COLLECTION_NAME + '.json'
 
     OBS_PROFILE_TEMPLATE_PATH = os.path.join(os.getcwd(), 'thirdparty', 'obsConfigs', 'profile')
-    OBS_PROFILE_DIR_PATH = r'C:\Users\user\AppData\Roaming\obs-studio\basic\profiles'
+    OBS_PROFILE_DIR_PATH = os.path.join(CommonUtil.get_appdata_dir(), 'obs-studio', 'basic', 'profiles')
+
     OBS_32BIT_BIN_DIR_PATH = r'C:\Program Files (x86)\obs-studio\bin\32bit'
     OBS_32BIT_BIN_PATH = r'C:\Program Files (x86)\obs-studio\bin\32bit\obs32.exe'
 
@@ -42,7 +43,7 @@ class ObsProfiler(BaseProfiler):
     OBS_PROFILE_BASIC_INI_FN = 'basic.ini'
     OBS_PROFILE_NAME = 'Hasal'
     OBS_RECORDING_FMT = 'mp4'
-    OBS_VIDEO_OUTPUT_DIR_PATH = r'C:\Users\user\Videos\hasal'
+    OBS_VIDEO_OUTPUT_DIR_PATH = os.path.join(CommonUtil.get_user_dir(), 'Videos', '\hasal')
 
     def __init__(self, input_env, input_index_config, input_browser_type=None, input_sikuli_obj=None):
         super(ObsProfiler, self).__init__(input_env, input_index_config, input_browser_type, input_sikuli_obj)


### PR DESCRIPTION
We found the `USERNAME` of each Windows machines might be different from default name `user`.

So I try to implement the static methods for getting username, AppData folder, user home folder.
And then modifying the `obsProfile`'s paths.
