### PR TITLE
Adding Terminal Crop Region for comparing images

### DIFF
--- a/lib/baseTest.py
+++ b/lib/baseTest.py
@@ -7,6 +7,7 @@ import json
 import platform
 import unittest
 import helper.desktopHelper as desktopHelper
+import helper.terminalHelper as terminalHelper
 import lib.helper.videoHelper as videoHelper
 import lib.helper.targetHelper as targetHelper
 import helper.generatorHelper as generatorHelper
@@ -95,31 +96,13 @@ class BaseTest(unittest.TestCase):
                     height_browser, width_browser = desktopHelper.adjust_viewport(self.browser_type,
                                                                                   self.env.img_sample_dp,
                                                                                   self.env.img_output_sample_1_fn)
-                    height_offset = 0
-                    terminal_width = width_browser
-                    terminal_height = 60
-                    if self.current_platform_name == 'linux2':
-                        height_offset = 20
-                        terminal_height = 60
-                    elif self.current_platform_name == 'win32':
-                        if self.current_platform_ver == '10':
-                            logger.info("Move terminal window for Windows 10.")
-                            height_offset = -4
-                            terminal_height = 100
-                        elif self.current_platform_ver == '7':
-                            logger.info("Move terminal window for Windows 7.")
-                            height_offset = 0
-                            terminal_height = 80
-                        else:
-                            logger.info("Move terminal window for Windows.")
-                            height_offset = 0
-                            terminal_height = 80
-                    elif self.current_platform_name == 'darwin':
-                        # TODO: This offset settings only be tested on Mac Book Air
-                        height_offset = 25
-                        terminal_height = 80
-                    terminal_x = 0
-                    terminal_y = height_browser + height_offset
+                    # get the terminal location
+                    terminal_location = terminalHelper.get_terminal_location(0, 0, width_browser, height_browser)
+                    terminal_x = terminal_location.get('x', 0)
+                    terminal_y = terminal_location.get('y', 0)
+                    terminal_width = terminal_location.get('width', 0)
+                    terminal_height = terminal_location.get('height', 0)
+
                     logger.info('Move Terminal to (X,Y,W,H): ({}, {}, {}, {})'.format(terminal_x,
                                                                                       terminal_y,
                                                                                       terminal_width,

--- a/lib/common/imageUtil.py
+++ b/lib/common/imageUtil.py
@@ -14,6 +14,37 @@ from logConfig import get_logger
 logger = get_logger(__name__)
 
 
+class CropRegion(object):
+    """
+    Here's the Crop Region Fig
+
+    |----------------------------------|  ---             ---
+    |        |                         |   ^               ^
+    | Tab  X |                         |   V <= TAB_VIEW   |
+    |----------------------------------|  ---              |
+    |                                  |   ^               |
+    |                                  |   |               |
+    |                                  |   |               |
+    |            Web Page              |   | <= VIEWPORT   | <= BROWSER
+    |                                  |   |               |
+    |                                  |   |               |
+    |                                  |   v               v
+    |----------------------------------|  ---             ---
+
+    |----------------------------------|  ---
+    | $ Terminal> _                    |   ^ <= TERMINAL
+    |                                  |   V
+    |----------------------------------|  ---
+    """
+    # Hasal do NOT crop the original
+    ORIGINAL = 'original'
+
+    VIEWPORT = 'viewport'
+    TAB_VIEW = 'tab_view'
+    BROWSER = 'browser'
+    TERMINAL = 'terminal'
+
+
 def crop_image(input_sample_fp, output_sample_fp, coord=[]):
     """
     For template region matching.

--- a/lib/common/visualmetricsWrapper.py
+++ b/lib/common/visualmetricsWrapper.py
@@ -28,7 +28,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."""
 
 import copy
 from commonUtil import CommonUtil
-from ..helper.terminalHelper import get_terminal_location  # NOQA
 from ..thirdparty.visualmetrics import *  # NOQA
 from PIL import Image
 from logConfig import get_logger
@@ -48,37 +47,6 @@ def colors_are_similar(a, b, threshold=30):
         similar = False
 
     return similar
-
-
-def find_terminal_view(input_file, viewport):
-    """
-    Find the Region of imageUtil.CropRegion.TERMINAL.
-    @param input_file: image file.
-    @param viewport: {x, y', width, height} of VIEWPORT.
-    @return: {x, y', width, height}
-    """
-    try:
-        im = Image.open(input_file)
-        im_width, im_height = im.size
-
-        base_x = int(viewport.get('x', 0))
-        base_y = int(viewport.get('y', 0))
-        base_width = int(viewport.get('width', im_width))
-        base_height = int(viewport.get('height', 0))
-
-        # get Terminal location
-        terminal_location = get_terminal_location(base_x, base_y, base_width, base_height)
-
-        # Adjust the height (do not over the image height)
-        terminal_y = terminal_location.get('y')
-        bottom = min(im_height, terminal_y + terminal_location.get('height') + 25)
-        adj_terminal_height = bottom - terminal_y
-        terminal_location['height'] = adj_terminal_height
-
-    except Exception as e:
-        logger.error(e)
-        terminal_location = None
-    return terminal_location
 
 
 def find_tab_view(input_file, viewport):

--- a/lib/common/visualmetricsWrapper.py
+++ b/lib/common/visualmetricsWrapper.py
@@ -28,6 +28,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE."""
 
 import copy
 from commonUtil import CommonUtil
+from ..helper.terminalHelper import get_terminal_location  # NOQA
 from ..thirdparty.visualmetrics import *  # NOQA
 from PIL import Image
 from logConfig import get_logger
@@ -49,12 +50,37 @@ def colors_are_similar(a, b, threshold=30):
     return similar
 
 
+def find_terminal_view(input_file, viewport):
+    """
+    Find the Region of imageUtil.CropRegion.TERMINAL.
+    @param input_file: image file.
+    @param viewport: {x, y', width, height} of VIEWPORT.
+    @return: {x, y', width, height}
+    """
+    try:
+        im = Image.open(input_file)
+        im_width, im_height = im.size
+
+        base_x = int(viewport.get('x', 0))
+        base_y = int(viewport.get('y', 0))
+        base_width = int(viewport.get('width', im_width))
+        base_height = int(viewport.get('height', 0))
+
+        # get Terminal location
+        terminal_location = get_terminal_location(base_x, base_y, base_width, base_height)
+
+    except Exception as e:
+        logger.error(e)
+        terminal_location = None
+    return terminal_location
+
+
 def find_tab_view(input_file, viewport):
     """
-
-    @param file:
-    @param viewport:
-    @return:
+    Find the Region of imageUtil.CropRegion.TAB_VIEW.
+    @param file: image file.
+    @param viewport: {x, y', width, height} of VIEWPORT.
+    @return: {x, y', width, height}
     """
     try:
         im = Image.open(input_file)
@@ -164,6 +190,11 @@ def calculate_perceptual_speed_index(progress):
 
 
 def find_image_viewport(file):
+    """
+    Find the Region of imageUtil.CropRegion.VIEWPORT.
+    @param file: image file.
+    @return: {x, y', width, height}
+    """
     try:
         im = Image.open(file)
         width, height = im.size

--- a/lib/common/visualmetricsWrapper.py
+++ b/lib/common/visualmetricsWrapper.py
@@ -69,6 +69,12 @@ def find_terminal_view(input_file, viewport):
         # get Terminal location
         terminal_location = get_terminal_location(base_x, base_y, base_width, base_height)
 
+        # Adjust the height (do not over the image height)
+        terminal_y = terminal_location.get('y')
+        bottom = min(im_height, terminal_y + terminal_location.get('height') + 25)
+        adj_terminal_height = bottom - terminal_y
+        terminal_location['height'] = adj_terminal_height
+
     except Exception as e:
         logger.error(e)
         terminal_location = None

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -3,6 +3,7 @@ import json
 import time
 import copy
 from baseGenerator import BaseGenerator
+from ..helper.terminalHelper import find_terminal_view
 from ..common.commonUtil import CommonUtil
 from ..common.commonUtil import CalculationUtil
 from ..common.imageUtil import generate_crop_data
@@ -11,7 +12,6 @@ from ..common.imageUtil import convert_to_dct
 from ..common.imageUtil import compare_with_sample_image_multi_process
 from ..common.imageUtil import CropRegion
 from ..common.visualmetricsWrapper import find_image_viewport
-from ..common.visualmetricsWrapper import find_terminal_view
 from ..common.logConfig import get_logger
 
 logger = get_logger(__name__)

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -9,7 +9,9 @@ from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
 from ..common.imageUtil import convert_to_dct
 from ..common.imageUtil import compare_with_sample_image_multi_process
+from ..common.imageUtil import CropRegion
 from ..common.visualmetricsWrapper import find_image_viewport
+from ..common.visualmetricsWrapper import find_terminal_view
 from ..common.logConfig import get_logger
 
 logger = get_logger(__name__)
@@ -17,13 +19,11 @@ logger = get_logger(__name__)
 
 class InputLatencyAnimationDctGenerator(BaseGenerator):
 
-    SEARCH_TARGET_VIEWPORT = 'viewport'
-    SEARCH_TARGET_ORIGINAL = 'original'
     SKIP_STATUS_BAR_FRACTION = 1.0
 
     BROWSER_VISUAL_EVENT_POINTS = {
-        'backward_search': [{'event': 'end', 'search_target': SEARCH_TARGET_VIEWPORT, 'fraction': SKIP_STATUS_BAR_FRACTION, 'shift_result': True},
-                            {'event': 'start', 'search_target': SEARCH_TARGET_ORIGINAL, 'fraction': SKIP_STATUS_BAR_FRACTION, 'shift_result': True}]
+        'backward_search': [{'event': 'end', 'search_target': CropRegion.VIEWPORT, 'fraction': SKIP_STATUS_BAR_FRACTION, 'shift_result': True},
+                            {'event': 'start', 'search_target': CropRegion.TERMINAL, 'fraction': SKIP_STATUS_BAR_FRACTION, 'shift_result': True}]
     }
 
     @staticmethod
@@ -35,12 +35,26 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
 
         # crop sample data area
         # generate viewport crop area
-        if InputLatencyAnimationDctGenerator.SEARCH_TARGET_VIEWPORT in input_sample_data:
-            return_result[input_generator_name]['crop_data'][InputLatencyAnimationDctGenerator.SEARCH_TARGET_VIEWPORT] = input_sample_data[InputLatencyAnimationDctGenerator.SEARCH_TARGET_VIEWPORT]
+        if CropRegion.VIEWPORT in input_sample_data:
+            # if already generated the data, reuse it.
+            return_result[input_generator_name]['crop_data'][CropRegion.VIEWPORT] = input_sample_data[CropRegion.VIEWPORT]
         else:
             viewport_value = find_image_viewport(input_sample_data['fp'])
-            return_result[input_generator_name]['crop_data'][InputLatencyAnimationDctGenerator.SEARCH_TARGET_VIEWPORT] = viewport_value
-            return_result[InputLatencyAnimationDctGenerator.SEARCH_TARGET_VIEWPORT] = viewport_value
+            return_result[input_generator_name]['crop_data'][CropRegion.VIEWPORT] = viewport_value
+            return_result[CropRegion.VIEWPORT] = viewport_value
+
+        # generate terminal crop area
+        if CropRegion.TERMINAL in input_sample_data:
+            # if already generated the data, reuse it.
+            return_result[input_generator_name]['crop_data'][CropRegion.TERMINAL] = input_sample_data[CropRegion.TERMINAL]
+        else:
+            # TODO: we should replace the VIEWPORT location by BROWSER location in the future.
+            # (Currently Mike implement the Win and Mac, no Linux)
+            terminal_value = find_terminal_view(
+                input_sample_data['fp'],
+                return_result[input_generator_name]['crop_data'][CropRegion.VIEWPORT])
+            return_result[input_generator_name]['crop_data'][CropRegion.TERMINAL] = terminal_value
+            return_result[CropRegion.TERMINAL] = terminal_value
 
         # generate crop data
         if input_generator_name not in input_sample_dict[1]:
@@ -55,7 +69,7 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
         if input_sample_index == 2:
             # tag event to sample
             for event_obj in InputLatencyAnimationDctGenerator.BROWSER_VISUAL_EVENT_POINTS['backward_search']:
-                if event_obj['search_target'] == InputLatencyAnimationDctGenerator.SEARCH_TARGET_ORIGINAL:
+                if event_obj['search_target'] == CropRegion.ORIGINAL:
                     return_result[input_generator_name]['event_tags'][event_obj['event']] = sample_dct_obj
                 else:
                     search_target_fp = crop_data_dict[event_obj['search_target']]['fp_list'][0]['output_fp']
@@ -91,7 +105,7 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
 
         # merge crop data and convert data
         for image_fn in input_image_list:
-            input_image_list[image_fn][self.SEARCH_TARGET_ORIGINAL] = input_image_list[image_fn]['fp']
+            input_image_list[image_fn][CropRegion.ORIGINAL] = input_image_list[image_fn]['fp']
 
         return input_image_list
 

--- a/lib/helper/terminalHelper.py
+++ b/lib/helper/terminalHelper.py
@@ -25,27 +25,27 @@ def get_terminal_location(browser_x, browser_y, browser_w, browser_h):
     terminal_width = base_width
     terminal_height = 60
     if platform_name == 'linux2':
-        logger.info("Move terminal window for Linux.")
+        logger.info('Get terminal window offset for Linux.')
         height_offset = 20
         terminal_height = 60
 
     elif platform_name == 'win32':
         if platform_release == '10':
-            logger.info("Move terminal window for Windows 10.")
+            logger.info('Get terminal window offset for Windows 10.')
             height_offset = -4
             terminal_height = 100
         elif platform_release == '7':
-            logger.info("Move terminal window for Windows 7.")
+            logger.info('Get terminal window offset for Windows 7.')
             height_offset = 0
             terminal_height = 80
         else:
-            logger.info("Move terminal window for Windows.")
+            logger.info('Get terminal window offset for Windows.')
             height_offset = 0
             terminal_height = 80
 
     elif platform_name == 'darwin':
         # TODO: This offset settings only be tested on Mac Book Air
-        logger.info("Move terminal window for Mac OSX.")
+        logger.info('Get terminal window offset for Mac OSX.')
         height_offset = 25
         terminal_height = 80
 

--- a/lib/helper/terminalHelper.py
+++ b/lib/helper/terminalHelper.py
@@ -1,0 +1,55 @@
+import sys
+import platform
+from ..common.logConfig import get_logger
+
+logger = get_logger(__name__)
+
+
+def get_terminal_location(browser_x, browser_y, browser_w, browser_h):
+    """
+    Get the terminal location base on browser location.
+    @param browser_x: the browser x base.
+    @param browser_y: the browser y base.
+    @param browser_w: the browser width.
+    @param browser_h: the browser height.
+    @return: the location of Termianl, {x, y, withd, height}
+    """
+    platform_name = sys.platform
+    platform_release = platform.release()
+
+    base_width = int(browser_x + browser_w)
+    base_height = int(browser_y + browser_h)
+
+    height_offset = 0
+    terminal_width = base_width
+    terminal_height = 60
+    if platform_name == 'linux2':
+        logger.info("Move terminal window for Linux.")
+        height_offset = 20
+        terminal_height = 60
+
+    elif platform_name == 'win32':
+        if platform_release == '10':
+            logger.info("Move terminal window for Windows 10.")
+            height_offset = -4
+            terminal_height = 100
+        elif platform_release == '7':
+            logger.info("Move terminal window for Windows 7.")
+            height_offset = 0
+            terminal_height = 80
+        else:
+            logger.info("Move terminal window for Windows.")
+            height_offset = 0
+            terminal_height = 80
+
+    elif platform_name == 'darwin':
+        # TODO: This offset settings only be tested on Mac Book Air
+        logger.info("Move terminal window for Mac OSX.")
+        height_offset = 25
+        terminal_height = 80
+
+    terminal_x = browser_x
+    terminal_y = base_height + height_offset
+
+    location = {'x': terminal_x, 'y': terminal_y, 'width': terminal_width, 'height': terminal_height}
+    return location


### PR DESCRIPTION
- Adding terminalHelper for handling Terminal location.
- Adding imageUtil.CropRegion for Crop Region's naming.
- Adding visualmetricsWrapper.find_terminal_view for comparing.
- Modifying inputLatencyAnimationDctGenerator for finding "start" by Terminal Region

Few weeks ago, @ShakoHo, @MikeLien and I have a discussion on comparing images for finding events, e.g. "start" and "end".
We found the "start" event of Input Latency cases by comparing the full screenshot (original image).
However, the IL cases will print the LOG on the Terminal when triggering the action.
We only want to compare the Terminal Region to find the "start" event for preciseness.
That's why I try to crop the Terminal Region from Original images.
