### PR TITLE
Customizing the InputLatencyCalcutionUtil for 0 frame issue when start and end at the same time, and modifying the event comparing result list data structure

### DIFF
--- a/lib/common/imageUtil.py
+++ b/lib/common/imageUtil.py
@@ -346,7 +346,7 @@ def parallel_compare_image(input_sample_data, input_image_data, input_settings, 
         event_name = event_point['event']
         search_target = event_point['search_target']
 
-        logger.info('Comapre event [{event_name}] at [{search_target}]: {forward_backward} from {start} to {end}'
+        logger.info('Compare event [{event_name}] at [{search_target}]: {forward_backward} from {start} to {end}'
                     .format(event_name=event_name,
                             search_target=search_target,
                             forward_backward='Forward' if forward_search else 'Backward',
@@ -406,6 +406,7 @@ def parallel_compare_image(input_sample_data, input_image_data, input_settings, 
                                     break
                                 start_index = min(img_index + total_search_range / 2, search_range[3] - 1)
                                 logger.debug('Change start: {start}'.format(start=start_index))
+                            # compare the same image, reset current image index from new start
                             img_index = start_index
                         else:
                             # shift one index to avoid boundary matching two events at the same time
@@ -426,6 +427,8 @@ def parallel_compare_image(input_sample_data, input_image_data, input_settings, 
                             search_count = 0
                             result_list.append({'event': event_name, 'file': input_image_data[img_fn_key]['fp'], 'time_seq': input_image_data[img_fn_key]['time_seq']})
                             logger.debug("Comparing %s point end %s" % (event_name, time.strftime("%c")))
+                            # compare next image, reset current image index from start
+                            img_index = start_index
                             break
                     else:
                         if forward_search:

--- a/lib/common/imageUtil.py
+++ b/lib/common/imageUtil.py
@@ -232,6 +232,11 @@ def crop_multiple_images(input_image_list, input_crop_area):
 def compare_with_sample_image_multi_process(input_sample_data, input_image_data, input_settings):
     """
     Compare sample images, return matching list.
+    return example:
+        [
+            {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487},
+            {'event': 'end', 'file': 'foo/bar/9527.bmp', 'time_seq': 5566.5566}, ...
+        ]
     @param input_sample_dp: input sample folder path
     @return: the matching result list
     """
@@ -407,7 +412,7 @@ def parallel_compare_image(input_sample_data, input_image_data, input_settings, 
                             if shift_result_flag:
                                 img_fn_key = image_fn_list[start_index]
                             search_count = 0
-                            result_list.append({event_name: input_image_data[img_fn_key]['fp'], 'time_seq': input_image_data[img_fn_key]['time_seq']})
+                            result_list.append({'event': event_name, 'file': input_image_data[img_fn_key]['fp'], 'time_seq': input_image_data[img_fn_key]['time_seq']})
                             logger.debug("Comparing %s point end %s" % (event_name, time.strftime("%c")))
                             break
                     else:

--- a/lib/generator/frameThroughputDctGenerator.py
+++ b/lib/generator/frameThroughputDctGenerator.py
@@ -233,18 +233,21 @@ class FrameThroughputDctGenerator(BaseGenerator):
             self.record_runtime_current_status(self.compare_result['run_time'])
 
             history_result_data = CommonUtil.load_json_file(self.env.DEFAULT_TEST_RESULT)
-            time_sequence = self.compare_result.get('time_sequence', [])
+            event_time_dict = self.compare_result.get('event_time_dict', {})
             long_frame = self.compare_result.get('long_frame', 0)
             frame_throughput = self.compare_result.get('frame_throughput', 0)
             freeze_frames = self.compare_result.get('freeze_frames', 0)
             expected_frames = self.compare_result.get('expected_frames', 0)
             actual_paint_frames = self.compare_result.get('actual_paint_frames', 0)
 
-            run_time_dict = {'run_time': self.compare_result['run_time'], 'folder': self.env.output_name,
-                             'freeze_frames': freeze_frames, 'long_frame': long_frame, 'frame_throughput': frame_throughput,
-                             'expected_frames': expected_frames, 'actual_paint_frames': actual_paint_frames,
-                             'time_sequence': time_sequence}
-            run_time_dict.update(self.compare_result['event_time_dict'])
+            run_time_dict = {'run_time': self.compare_result['run_time'],
+                             'folder': self.env.output_name,
+                             'freeze_frames': freeze_frames,
+                             'long_frame': long_frame,
+                             'frame_throughput': frame_throughput,
+                             'expected_frames': expected_frames,
+                             'actual_paint_frames': actual_paint_frames,
+                             'event_time': event_time_dict}
 
             # init result dict if not exist
             init_result_dict = self.init_result_dict_variable(

--- a/lib/generator/frameThroughputDctGenerator.py
+++ b/lib/generator/frameThroughputDctGenerator.py
@@ -33,7 +33,12 @@ class FrameThroughputDctGenerator(BaseGenerator):
     def get_frame_throughput(self, result_list, input_image_list):
         """
 
-        @param result_list:
+        @param result_list: the running_time_result after do comparison.
+            ex:
+            [
+                {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487},
+                {'event': 'end', 'file': 'foo/bar/9527.bmp', 'time_seq': 5566.5566}, ...
+            ]
         @param input_image_list:
         @return:
         """
@@ -44,13 +49,12 @@ class FrameThroughputDctGenerator(BaseGenerator):
             image_fn_list.sort(key=CommonUtil.natural_keys)
 
             # get start point and end point from input data
-            start_event_fp = None
-            end_event_fp = None
-            for result in result_list:
-                if 'start' in result:
-                    start_event_fp = result['start']
-                if 'end' in result:
-                    end_event_fp = result['end']
+            start_event = CalculationUtil.get_event_data_in_result_list(result_list,
+                                                                        CalculationUtil.EVENT_START)
+            end_event = CalculationUtil.get_event_data_in_result_list(result_list,
+                                                                      CalculationUtil.EVENT_END)
+            start_event_fp = start_event.get('file', None)
+            end_event_fp = end_event.get('file', None)
             if not start_event_fp or not end_event_fp:
                 raise Exception('[ERROR] Cannot find either start point or end point!')
             else:

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -6,6 +6,7 @@ import numpy as np
 from baseGenerator import BaseGenerator
 from ..helper.terminalHelper import find_terminal_view
 from ..common.commonUtil import CommonUtil
+from ..common.commonUtil import CalculationUtil
 from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
 from ..common.imageUtil import convert_to_dct
@@ -148,10 +149,10 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             self.record_runtime_current_status(self.compare_result['run_time'])
 
             history_result_data = CommonUtil.load_json_file(self.env.DEFAULT_TEST_RESULT)
-            time_sequence = self.compare_result.get('time_seq', [])
-            run_time_dict = {'run_time': self.compare_result['run_time'], 'folder': self.env.output_name,
-                             'time_seq': time_sequence}
-            run_time_dict.update(self.compare_result['event_time_dict'])
+            event_time_dict = self.compare_result.get('event_time_dict', {})
+            run_time_dict = {'run_time': self.compare_result['run_time'],
+                             'folder': self.env.output_name,
+                             'event_time': event_time_dict}
 
             # init result dict if not exist
             init_result_dict = self.init_result_dict_variable(
@@ -178,7 +179,8 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             logger.debug("Generate Video Elapsed: [%s]" % elapsed_time)
 
 
-class InputLatencyCalcutionUtil(object):
+class InputLatencyCalcutionUtil(CalculationUtil):
+
     @staticmethod
     def calculate_runtime_base_on_event(input_running_time_result, fps):
         """
@@ -187,27 +189,37 @@ class InputLatencyCalcutionUtil(object):
 
         For example, if FPS is 90, the running time of 1 frame is 11.11111 ms.
         When start and end at the same time, it will return 5.55555 ms ((1000 ms / 90 FPS) / 2).
-        @param input_running_time_result: the running_time_result after do comparison
-        @param fps: the current FPS
-        @return: (running time, the dict of all events' time sequence)
+        @param input_running_time_result: the running_time_result after do comparison.
+            ex:
+            [
+                {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487},
+                {'event': 'end', 'file': 'foo/bar/9527.bmp', 'time_seq': 5566.5566}, ...
+            ]
+        @param fps: the current FPS.
+        @return: (running time, the dict of all events' time sequence).
         """
         run_time = -1
-        comparing_time_data = {}
-        for event_data in input_running_time_result:
-            for time_point in ['start', 'end']:
-                if time_point in event_data:
-                    comparing_time_data[time_point] = event_data['time_seq']
-                    break
         event_time_dict = dict()
-        if len(comparing_time_data.keys()) == 2:
-            run_time = comparing_time_data['end'] - comparing_time_data['start']
+
+        start_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
+                                                                    CalculationUtil.EVENT_START)
+        end_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
+                                                                  CalculationUtil.EVENT_END)
+        if start_event and end_event:
+            run_time = end_event.get('time_seq') - start_event.get('time_seq')
+            event_time_dict[CalculationUtil.EVENT_START] = 0
+            event_time_dict[CalculationUtil.EVENT_END] = run_time
+
+            # when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
             if run_time == 0:
-                # start and end at the same time, return the mid time between 0~1 frame
                 run_time = 1000.0 / fps / 2
+
             if run_time > 0:
-                for event_data in input_running_time_result:
-                    for event_name in event_data:
-                        if event_name != 'time_seq' and event_name != 'start' and event_name != 'end':
-                            event_time_dict[event_name] = np.absolute(
-                                event_data['time_seq'] - comparing_time_data['start'])
+                for custom_event in input_running_time_result:
+                    custom_event_name = custom_event.get('event')
+                    if custom_event_name != CalculationUtil.EVENT_START \
+                            and custom_event_name != CalculationUtil.EVENT_END:
+                        event_time_dict[custom_event_name] = np.absolute(
+                            custom_event.get('time_seq') - start_event.get('time_seq'))
+
         return run_time, event_time_dict

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -2,10 +2,10 @@ import os
 import json
 import time
 import copy
+import numpy as np
 from baseGenerator import BaseGenerator
 from ..helper.terminalHelper import find_terminal_view
 from ..common.commonUtil import CommonUtil
-from ..common.commonUtil import CalculationUtil
 from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
 from ..common.imageUtil import convert_to_dct
@@ -134,7 +134,11 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             compare_setting)
 
         if self.compare_result.get('running_time_result', None):
-            run_time, event_time_dict = CalculationUtil.runtime_calculation_event_point_base(self.compare_result['running_time_result'])
+            # Calculate the Input Latency running time by InputLatencyCalcutionUtil class
+            run_time, event_time_dict = InputLatencyCalcutionUtil.calculate_runtime_base_on_event(
+                self.compare_result['running_time_result'],
+                self.index_config['video-recording-fps'])
+
             self.compare_result.update({'run_time': run_time, 'event_time_dict': event_time_dict})
         return self.compare_result
 
@@ -144,9 +148,9 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             self.record_runtime_current_status(self.compare_result['run_time'])
 
             history_result_data = CommonUtil.load_json_file(self.env.DEFAULT_TEST_RESULT)
-            time_sequence = self.compare_result.get('time_sequence', [])
+            time_sequence = self.compare_result.get('time_seq', [])
             run_time_dict = {'run_time': self.compare_result['run_time'], 'folder': self.env.output_name,
-                             'time_sequence': time_sequence}
+                             'time_seq': time_sequence}
             run_time_dict.update(self.compare_result['event_time_dict'])
 
             # init result dict if not exist
@@ -172,3 +176,38 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             current_time = time.time()
             elapsed_time = current_time - start_time
             logger.debug("Generate Video Elapsed: [%s]" % elapsed_time)
+
+
+class InputLatencyCalcutionUtil(object):
+    @staticmethod
+    def calculate_runtime_base_on_event(input_running_time_result, fps):
+        """
+        This method base on `commonUtil.CalculationUtil.runtime_calculation_event_point_base`.
+        However, when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
+
+        For example, if FPS is 90, the running time of 1 frame is 11.11111 ms.
+        When start and end at the same time, it will return 5.55555 ms ((1000 ms / 90 FPS) / 2).
+        @param input_running_time_result: the running_time_result after do comparison
+        @param fps: the current FPS
+        @return: (running time, the dict of all events' time sequence)
+        """
+        run_time = -1
+        comparing_time_data = {}
+        for event_data in input_running_time_result:
+            for time_point in ['start', 'end']:
+                if time_point in event_data:
+                    comparing_time_data[time_point] = event_data['time_seq']
+                    break
+        event_time_dict = dict()
+        if len(comparing_time_data.keys()) == 2:
+            run_time = comparing_time_data['end'] - comparing_time_data['start']
+            if run_time == 0:
+                # start and end at the same time, return the mid time between 0~1 frame
+                run_time = 1000.0 / fps / 2
+            if run_time > 0:
+                for event_data in input_running_time_result:
+                    for event_name in event_data:
+                        if event_name != 'time_seq' and event_name != 'start' and event_name != 'end':
+                            event_time_dict[event_name] = np.absolute(
+                                event_data['time_seq'] - comparing_time_data['start'])
+        return run_time, event_time_dict

--- a/lib/generator/runTimeDctGenerator.py
+++ b/lib/generator/runTimeDctGenerator.py
@@ -159,12 +159,14 @@ class RunTimeDctGenerator(BaseGenerator):
             self.record_runtime_current_status(self.compare_result['run_time'])
 
             history_result_data = CommonUtil.load_json_file(self.env.DEFAULT_TEST_RESULT)
-            time_sequence = self.compare_result.get('time_sequence', [])
+            event_time_dict = self.compare_result.get('event_time_dict', {})
             si_value = self.compare_result.get('speed_index', 0)
             psi_value = self.compare_result.get('perceptual_speed_index', 0)
-            run_time_dict = {'run_time': self.compare_result['run_time'], 'folder': self.env.output_name,
-                             'time_sequence': time_sequence, 'si': si_value, 'psi': psi_value}
-            run_time_dict.update(self.compare_result['event_time_dict'])
+            run_time_dict = {'run_time': self.compare_result['run_time'],
+                             'folder': self.env.output_name,
+                             'event_time': event_time_dict,
+                             'si': si_value,
+                             'psi': psi_value}
 
             # init result dict if not exist
             init_result_dict = self.init_result_dict_variable(

--- a/lib/perfBaseTest.py
+++ b/lib/perfBaseTest.py
@@ -71,10 +71,12 @@ class PerfBaseTest(baseTest.BaseTest):
         # capture 2nd snapshot
         time.sleep(5)
 
-        if self.env.PROFILER_FLAG_AVCONV in self.env.firefox_settings_extensions:
-            if self.env.firefox_settings_extensions[self.env.PROFILER_FLAG_AVCONV]['enable'] is True and self.index_config['snapshot-base-sample2'] is True:
-                videoHelper.capture_screen(self.env, self.index_config, self.exec_config, self.env.video_output_sample_2_fp, self.env.img_sample_dp,
-                                           self.env.img_output_sample_2_fn)
+        recording_enabled = CommonUtil.is_video_recording(self.firefox_config)
+        if recording_enabled and self.index_config.get('snapshot-base-sample2', False) is True:
+            videoHelper.capture_screen(self.env, self.index_config, self.exec_config,
+                                       self.env.video_output_sample_2_fp,
+                                       self.env.img_sample_dp,
+                                       self.env.img_output_sample_2_fn)
 
         # Stop profiler and save profile data
         self.profilers.stop_profiling(self.profile_dir_path)


### PR DESCRIPTION
- Customizing the InputLatencyCalcutionUtil for 0 frame issue when `start` and `end` at the same time.
- Modifying the return data structure of event comparing result list from `[{'start': 'foo/bar/img.bmp', 'time_seq': 9527}, {...}]` to `[{'event': 'start', 'file': 'foo/bar/img.bmp', 'time_seq': 9527}, {...}]`.
- Refactoring the `runtime` and `frameThroughput` generators for new event comparing result list data structure. Also modifying the `get_frame_throughput()` for `frameThroughput` generator.
- Fixing the inconsistent issue of `search-range` and `converted images length` when CV2 converter failed.
- Resetting the current image-index when we start to compare the next event's images.
- Modifying the `tearDown()` for supporting the 2nd snapshot with multiple recorders.
