### PR TITLE
Moving the running time calculation method from `commonUtil.CalculationUtil` to `basGenerator`

### DIFF
--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -65,50 +65,6 @@ class StatusRecorder(object):
 
 class CalculationUtil(object):
 
-    EVENT_START = 'start'
-    EVENT_END = 'end'
-
-    @staticmethod
-    def get_event_data_in_result_list(event_result_list, event_name):
-        """
-        Return the event object which
-        @param event_result_list: the running_time_result after do comparison.
-            ex:
-            [
-                {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487},
-                {'event': 'end', 'file': 'foo/bar/9527.bmp', 'time_seq': 5566.5566}, ...
-            ]
-        @param event_name: the event name
-        @return: return the object of event, ex: {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487}
-        """
-        ret_list = filter(lambda x: x.get('event') == event_name, event_result_list)
-        if len(ret_list) > 0:
-            return ret_list[0]
-        return None
-
-    @staticmethod
-    def runtime_calculation_event_point_base(input_running_time_result):
-        run_time = -1
-        event_time_dict = dict()
-
-        start_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
-                                                                    CalculationUtil.EVENT_START)
-        end_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
-                                                                  CalculationUtil.EVENT_END)
-        if start_event and end_event:
-            run_time = end_event.get('time_seq') - start_event.get('time_seq')
-            event_time_dict[CalculationUtil.EVENT_START] = 0
-            event_time_dict[CalculationUtil.EVENT_END] = run_time
-
-            if run_time > 0:
-                for custom_event in input_running_time_result:
-                    custom_event_name = custom_event.get('event')
-                    if custom_event_name != CalculationUtil.EVENT_START \
-                            and custom_event_name != CalculationUtil.EVENT_END:
-                        event_time_dict[custom_event_name] = custom_event.get('time_seq') - start_event.get('time_seq')
-
-        return run_time, event_time_dict
-
     @staticmethod
     def Q_MooreMcCabe(seq):
         seq_len = len(seq)

--- a/lib/generator/baseGenerator.py
+++ b/lib/generator/baseGenerator.py
@@ -201,8 +201,8 @@ class BaseGenerator(object):
             return ret_list[0]
         return None
 
-    @staticmethod
-    def calculate_runtime_base_on_event(input_running_time_result, **kwargs):
+    @classmethod
+    def calculate_runtime_base_on_event(cls, input_running_time_result):
         """
         Calculate the running time base on input event result list.
         The value comes from the "time_seq" of "start" and "end" event.
@@ -218,20 +218,20 @@ class BaseGenerator(object):
         run_time = -1
         event_time_dict = dict()
 
-        start_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
-                                                                  BaseGenerator.EVENT_START)
-        end_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
-                                                                BaseGenerator.EVENT_END)
+        start_event = cls.get_event_data_in_result_list(input_running_time_result,
+                                                        cls.EVENT_START)
+        end_event = cls.get_event_data_in_result_list(input_running_time_result,
+                                                      cls.EVENT_END)
         if start_event and end_event:
             run_time = end_event.get('time_seq') - start_event.get('time_seq')
-            event_time_dict[BaseGenerator.EVENT_START] = 0
-            event_time_dict[BaseGenerator.EVENT_END] = run_time
+            event_time_dict[cls.EVENT_START] = 0
+            event_time_dict[cls.EVENT_END] = run_time
 
             if run_time > 0:
                 for custom_event in input_running_time_result:
                     custom_event_name = custom_event.get('event')
-                    if custom_event_name != BaseGenerator.EVENT_START \
-                            and custom_event_name != BaseGenerator.EVENT_END:
+                    if custom_event_name != cls.EVENT_START \
+                            and custom_event_name != cls.EVENT_END:
                         event_time_dict[custom_event_name] = custom_event.get('time_seq') - start_event.get('time_seq')
 
         return run_time, event_time_dict

--- a/lib/generator/frameThroughputDctGenerator.py
+++ b/lib/generator/frameThroughputDctGenerator.py
@@ -48,10 +48,10 @@ class FrameThroughputDctGenerator(BaseGenerator):
             image_fn_list.sort(key=CommonUtil.natural_keys)
 
             # get start point and end point from input data
-            start_event = BaseGenerator.get_event_data_in_result_list(result_list,
-                                                                      BaseGenerator.EVENT_START)
-            end_event = BaseGenerator.get_event_data_in_result_list(result_list,
-                                                                    BaseGenerator.EVENT_END)
+            start_event = self.get_event_data_in_result_list(result_list,
+                                                             self.EVENT_START)
+            end_event = self.get_event_data_in_result_list(result_list,
+                                                           self.EVENT_END)
             start_event_fp = start_event.get('file', None)
             end_event_fp = end_event.get('file', None)
             if not start_event_fp or not end_event_fp:

--- a/lib/generator/frameThroughputDctGenerator.py
+++ b/lib/generator/frameThroughputDctGenerator.py
@@ -4,7 +4,6 @@ import time
 import copy
 import numpy as np
 from baseGenerator import BaseGenerator
-from ..common.commonUtil import CalculationUtil
 from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
 from ..common.imageUtil import convert_to_dct
@@ -49,10 +48,10 @@ class FrameThroughputDctGenerator(BaseGenerator):
             image_fn_list.sort(key=CommonUtil.natural_keys)
 
             # get start point and end point from input data
-            start_event = CalculationUtil.get_event_data_in_result_list(result_list,
-                                                                        CalculationUtil.EVENT_START)
-            end_event = CalculationUtil.get_event_data_in_result_list(result_list,
-                                                                      CalculationUtil.EVENT_END)
+            start_event = BaseGenerator.get_event_data_in_result_list(result_list,
+                                                                      BaseGenerator.EVENT_START)
+            end_event = BaseGenerator.get_event_data_in_result_list(result_list,
+                                                                    BaseGenerator.EVENT_END)
             start_event_fp = start_event.get('file', None)
             end_event_fp = end_event.get('file', None)
             if not start_event_fp or not end_event_fp:
@@ -225,7 +224,7 @@ class FrameThroughputDctGenerator(BaseGenerator):
             compare_setting)
         # get frame throughput values
         if self.compare_result.get('running_time_result', None):
-            run_time, event_time_dict = CalculationUtil.runtime_calculation_event_point_base(self.compare_result['running_time_result'])
+            run_time, event_time_dict = self.calculate_runtime_base_on_event(self.compare_result['running_time_result'])
             self.compare_result.update({'run_time': run_time, 'event_time_dict': event_time_dict})
             self.compare_result.update(self.get_frame_throughput(self.compare_result['running_time_result'], self.compare_result['merged_crop_image_list']))
 

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -177,8 +177,8 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             elapsed_time = current_time - start_time
             logger.debug("Generate Video Elapsed: [%s]" % elapsed_time)
 
-    @staticmethod
-    def calculate_runtime_base_on_event(input_running_time_result, fps):
+    @classmethod
+    def calculate_runtime_base_on_event(cls, input_running_time_result, fps=90):
         """
         This customized method base on `baseGenerator.runtime_calculation_event_point_base`.
         However, when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
@@ -191,20 +191,20 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
                 {'event': 'start', 'file': 'foo/bar/9487.bmp', 'time_seq': 5487.9487},
                 {'event': 'end', 'file': 'foo/bar/9527.bmp', 'time_seq': 5566.5566}, ...
             ]
-        @param fps: the current FPS.
+        @param fps: the current FPS. Default=90.
         @return: (running time, the dict of all events' time sequence).
         """
         run_time = -1
         event_time_dict = dict()
 
-        start_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
-                                                                  BaseGenerator.EVENT_START)
-        end_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
-                                                                BaseGenerator.EVENT_END)
+        start_event = cls.get_event_data_in_result_list(input_running_time_result,
+                                                        cls.EVENT_START)
+        end_event = cls.get_event_data_in_result_list(input_running_time_result,
+                                                      cls.EVENT_END)
         if start_event and end_event:
             run_time = end_event.get('time_seq') - start_event.get('time_seq')
-            event_time_dict[BaseGenerator.EVENT_START] = 0
-            event_time_dict[BaseGenerator.EVENT_END] = run_time
+            event_time_dict[cls.EVENT_START] = 0
+            event_time_dict[cls.EVENT_END] = run_time
 
             # when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
             if run_time == 0:
@@ -213,8 +213,8 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             if run_time > 0:
                 for custom_event in input_running_time_result:
                     custom_event_name = custom_event.get('event')
-                    if custom_event_name != BaseGenerator.EVENT_START \
-                            and custom_event_name != BaseGenerator.EVENT_END:
+                    if custom_event_name != cls.EVENT_START \
+                            and custom_event_name != cls.EVENT_END:
                         event_time_dict[custom_event_name] = np.absolute(
                             custom_event.get('time_seq') - start_event.get('time_seq'))
 

--- a/lib/generator/inputLatencyAnimationDctGenerator.py
+++ b/lib/generator/inputLatencyAnimationDctGenerator.py
@@ -6,7 +6,6 @@ import numpy as np
 from baseGenerator import BaseGenerator
 from ..helper.terminalHelper import find_terminal_view
 from ..common.commonUtil import CommonUtil
-from ..common.commonUtil import CalculationUtil
 from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
 from ..common.imageUtil import convert_to_dct
@@ -135,8 +134,8 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             compare_setting)
 
         if self.compare_result.get('running_time_result', None):
-            # Calculate the Input Latency running time by InputLatencyCalcutionUtil class
-            run_time, event_time_dict = InputLatencyCalcutionUtil.calculate_runtime_base_on_event(
+            # Calculate the Input Latency running time by customized method
+            run_time, event_time_dict = self.calculate_runtime_base_on_event(
                 self.compare_result['running_time_result'],
                 self.index_config['video-recording-fps'])
 
@@ -178,13 +177,10 @@ class InputLatencyAnimationDctGenerator(BaseGenerator):
             elapsed_time = current_time - start_time
             logger.debug("Generate Video Elapsed: [%s]" % elapsed_time)
 
-
-class InputLatencyCalcutionUtil(CalculationUtil):
-
     @staticmethod
     def calculate_runtime_base_on_event(input_running_time_result, fps):
         """
-        This method base on `commonUtil.CalculationUtil.runtime_calculation_event_point_base`.
+        This customized method base on `baseGenerator.runtime_calculation_event_point_base`.
         However, when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
 
         For example, if FPS is 90, the running time of 1 frame is 11.11111 ms.
@@ -201,14 +197,14 @@ class InputLatencyCalcutionUtil(CalculationUtil):
         run_time = -1
         event_time_dict = dict()
 
-        start_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
-                                                                    CalculationUtil.EVENT_START)
-        end_event = CalculationUtil.get_event_data_in_result_list(input_running_time_result,
-                                                                  CalculationUtil.EVENT_END)
+        start_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
+                                                                  BaseGenerator.EVENT_START)
+        end_event = BaseGenerator.get_event_data_in_result_list(input_running_time_result,
+                                                                BaseGenerator.EVENT_END)
         if start_event and end_event:
             run_time = end_event.get('time_seq') - start_event.get('time_seq')
-            event_time_dict[CalculationUtil.EVENT_START] = 0
-            event_time_dict[CalculationUtil.EVENT_END] = run_time
+            event_time_dict[BaseGenerator.EVENT_START] = 0
+            event_time_dict[BaseGenerator.EVENT_END] = run_time
 
             # when start and end at the same time, it will return the mid time between 0~1 frame, not 0 ms.
             if run_time == 0:
@@ -217,8 +213,8 @@ class InputLatencyCalcutionUtil(CalculationUtil):
             if run_time > 0:
                 for custom_event in input_running_time_result:
                     custom_event_name = custom_event.get('event')
-                    if custom_event_name != CalculationUtil.EVENT_START \
-                            and custom_event_name != CalculationUtil.EVENT_END:
+                    if custom_event_name != BaseGenerator.EVENT_START \
+                            and custom_event_name != BaseGenerator.EVENT_END:
                         event_time_dict[custom_event_name] = np.absolute(
                             custom_event.get('time_seq') - start_event.get('time_seq'))
 

--- a/lib/generator/runTimeDctGenerator.py
+++ b/lib/generator/runTimeDctGenerator.py
@@ -3,7 +3,6 @@ import json
 import time
 import copy
 from baseGenerator import BaseGenerator
-from ..common.commonUtil import CalculationUtil
 from ..common.commonUtil import CommonUtil
 from ..common.imageUtil import generate_crop_data
 from ..common.imageUtil import crop_images
@@ -143,7 +142,7 @@ class RunTimeDctGenerator(BaseGenerator):
             input_image_list,
             compare_setting)
         if self.compare_result.get('running_time_result', None):
-            run_time, event_time_dict = CalculationUtil.runtime_calculation_event_point_base(self.compare_result['running_time_result'])
+            run_time, event_time_dict = self.calculate_runtime_base_on_event(self.compare_result['running_time_result'])
             self.compare_result.update({'run_time': run_time, 'event_time_dict': event_time_dict})
 
             if self.index_config['calculate-speed-index']:


### PR DESCRIPTION
After having a discussion with @ShakoHo and @MikeLien, we think it will be more reasonable if we move the running time calculation method from CalculationUtil to baseGenerator.
When sub-generators have to customize their own calculating methods, then they can override the "calculate_runtime_base_on_event" to fit the requirements.