### PR TITLE
Return the empty object if there is no matched event in result list

### DIFF
--- a/lib/generator/baseGenerator.py
+++ b/lib/generator/baseGenerator.py
@@ -221,7 +221,7 @@ class BaseGenerator(object):
         ret_list = filter(lambda x: x.get('event') == event_name, event_result_list)
         if len(ret_list) > 0:
             return ret_list[0]
-        return None
+        return {}
 
     @classmethod
     def calculate_runtime_base_on_event(cls, input_running_time_result):


### PR DESCRIPTION
Sometimes the event object have to get the attribute from event object:
```python
        # get start point and end point from input data
        start_event = self.get_event_data_in_result_list(running_time_result,
                                                         self.EVENT_START)
        end_event = self.get_event_data_in_result_list(running_time_result,
                                                       self.EVENT_END)
        start_fp = start_event.get('file', None)
        end_fp = end_event.get('file', None)
```