### PR TITLE
fix browser adjustment fail when os slower

### DIFF
--- a/lib/baseTest.py
+++ b/lib/baseTest.py
@@ -79,9 +79,8 @@ class BaseTest(unittest.TestCase):
             viewport = dict()
             viewport_ref_fp = os.path.join(self.env.img_sample_dp, self.env.img_output_sample_1_fn)
             is_expected_viewport = False
-            time.sleep(3)
             desktopHelper.lock_window_pos(self.browser_type, self.exec_config)
-            for i in range(20):
+            for i in range(25):
                 time.sleep(1)
                 videoHelper.capture_screen(self.env, self.index_config, self.exec_config,
                                            self.env.video_output_sample_1_fp,

--- a/lib/common/visualmetricsWrapper.py
+++ b/lib/common/visualmetricsWrapper.py
@@ -175,7 +175,9 @@ def find_image_viewport(file):
         x = int(math.floor(width / 4))
         y = int(math.floor(height / 4))
         pixels = im.load()
-        background = pixels[x, y]
+        white_rgb = (255, 255, 255)
+        # based on needs, set white color as target background
+        background = white_rgb
 
         # Find the left edge
         left = None

--- a/lib/common/windowController.py
+++ b/lib/common/windowController.py
@@ -89,7 +89,7 @@ class WindowObject(object):
     def _move_window_win32_cb(self, hwnd, extra):
         window_title = win32gui.GetWindowText(hwnd)
         for name in self.window_name_list:
-            if name in window_title:
+            if name in window_title and win32gui.IsWindowVisible(hwnd):
                 # move position
                 win32gui.SetWindowPos(hwnd, win32con.HWND_TOP, self.pos_x, self.pos_y, self.window_width,
                                       self.window_height, 0)
@@ -99,7 +99,7 @@ class WindowObject(object):
 
     def _move_window_win32(self):
         # try to move window after window launched
-        for counter in range(10):
+        for counter in range(20):
             win32gui.EnumWindows(self._move_window_win32_cb, None)
             if self.callback_ret:
                 self.callback_ret = None
@@ -111,7 +111,7 @@ class WindowObject(object):
     def _get_window_rect_cb(self, hwnd, extra):
         window_title = win32gui.GetWindowText(hwnd)
         for name in self.window_name_list:
-            if name in window_title:
+            if name in window_title and win32gui.IsWindowVisible(hwnd):
                 logger.info('Found [{}] for get rect.'.format(name))
                 self.rect = win32gui.GetWindowRect(hwnd)
                 self.callback_ret = True
@@ -119,7 +119,7 @@ class WindowObject(object):
 
     def _get_window_rect_win(self):
         # try to get window size after window launched
-        for counter in range(10):
+        for counter in range(20):
             win32gui.EnumWindows(self._get_window_rect_cb, None)
             if self.callback_ret:
                 self.callback_ret = None
@@ -152,7 +152,7 @@ class WindowObject(object):
 
     def _get_window_rect_darwin(self):
         # try to get window size after window launched
-        for counter in range(10):
+        for counter in range(20):
             for app_ref in app('System Events').processes.file.get():
                 for name in self.window_name_list:
                     if name in app_ref.name.get():
@@ -160,7 +160,7 @@ class WindowObject(object):
                         logger.info('Found [{}] for get rect.'.format(name))
                         for _ in range(10):
                             if application_obj.isrunning():
-                                # move window position
+                                # get window position
                                 # Reference: https://www.macosxautomation.com/applescript/firsttutorial/11.html
                                 rect = application_obj.windows.bounds.get()
                                 LL = rect[0]
@@ -189,7 +189,7 @@ class WindowObject(object):
 
     def _move_window_darwin(self):
         # try to move window after window launched
-        for counter in range(10):
+        for counter in range(20):
             for app_ref in app('System Events').processes.file.get():
                 for name in self.window_name_list:
                     if name in app_ref.name.get():

--- a/lib/helper/desktopHelper.py
+++ b/lib/helper/desktopHelper.py
@@ -4,7 +4,6 @@ import subprocess
 from ..common.windowController import WindowObject
 from ..common.environment import Environment
 from ..common.logConfig import get_logger
-from ..common.visualmetricsWrapper import find_image_viewport
 
 logger = get_logger(__name__)
 

--- a/lib/helper/desktopHelper.py
+++ b/lib/helper/desktopHelper.py
@@ -99,18 +99,20 @@ def lock_window_pos(browser_type, exec_config={}, height_adjustment=0, width_adj
     window_title_list = get_browser_name_list(browser_type)
     # Moving window by strings from window_title
     window_obj = WindowObject(window_title_list)
-    if window_obj.get_window_rect():
+
+    # First launch or just move position only need to get browser size from settings
+    if not height_adjustment and not width_adjustment:
+        if not exec_config:
+            height = Environment.DEFAULT_BROWSER_HEIGHT
+            width = Environment.DEFAULT_BROWSER_WIDTH
+        else:
+            height = exec_config['browser-height']
+            width = exec_config['browser-width']
+    else:
         browser_width = window_obj.rect[2]
         browser_height = window_obj.rect[3]
         height = browser_height + height_adjustment
         width = browser_width + width_adjustment
-    else:
-        if not exec_config:
-            height = Environment.DEFAULT_BROWSER_HEIGHT + height_adjustment
-            width = Environment.DEFAULT_BROWSER_WIDTH + width_adjustment
-        else:
-            height = exec_config['browser-height'] + height_adjustment
-            width = exec_config['browser-width'] + width_adjustment
     window_obj.move_window_pos(0, 0, window_height=height, window_width=width)
     return height, width
 
@@ -127,17 +129,24 @@ def minimize_window():
                 break
 
 
-def adjust_viewport(browser_type, viewport_ref_fp, exec_config):
-    viewport = find_image_viewport(viewport_ref_fp)
+def adjust_viewport(browser_type, viewport, exec_config):
     height_adjustment = exec_config['viewport-height'] - viewport['height']
     width_adjustment = exec_config['viewport-width'] - viewport['width']
     height, width = lock_window_pos(browser_type, exec_config, height_adjustment, width_adjustment)
     return height, width
 
 
-def is_expected_viewport(viewport_ref_fp, exec_config):
-    viewport = find_image_viewport(viewport_ref_fp)
+def is_expected_viewport(viewport, exec_config):
     if viewport['height'] == exec_config['viewport-height'] and viewport['width'] == exec_config['viewport-width']:
+        return True
+    else:
+        return False
+
+
+def is_above_half_viewport(viewport, exec_config):
+    half_viewport_height = exec_config['viewport-height'] * 0.5
+    half_viewport_width = exec_config['viewport-width'] * 0.5
+    if viewport['height'] >= half_viewport_height and viewport['width'] >= half_viewport_width:
         return True
     else:
         return False


### PR DESCRIPTION
1. set white color as target viewport background to compare
2. longer waiting time for checking window title exists
3. besides window title, check additional window visible attribute on windows
4. start adjustment until viewport above half setting