### PR TITLE
Adding General SikuliCase base class, and stat_fp for parameters transfer

### DIFF
--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -43,6 +43,15 @@ class StatusRecorder(object):
     def get_current_status(self):
         return self.current_status['current_status']
 
+    def get_current_sikuli_status(self):
+        """
+        Get the "sikuli" status from current status.
+        @return: the status object of "current_status/sikuli".
+        """
+        # reference: "lib/sikuli.py"
+        KEY_NAME_SIKULI = 'sikuli'
+        return self.current_status.get('current_status', {}).get(KEY_NAME_SIKULI, {})
+
     def record_current_status(self, input_status_dict):
         self.current_status = CommonUtil.load_json_file(self.status_fp)
         if 'current_status' in self.current_status:

--- a/lib/perfBaseTest.py
+++ b/lib/perfBaseTest.py
@@ -20,7 +20,8 @@ class PerfBaseTest(baseTest.BaseTest):
         super(PerfBaseTest, self).setUp()
 
         # init sikuli
-        self.sikuli = sikuli.Sikuli(self.env.run_sikulix_cmd_path, self.env.hasal_dir)
+        self.sikuli = sikuli.Sikuli(self.env.run_sikulix_cmd_path, self.env.hasal_dir,
+                                    running_statistics_file_path=self.global_config['default-running-statistics-fn'])
 
         # Start video recordings
         self.profilers = Profilers(self.env, self.index_config, self.exec_config, self.browser_type, self.sikuli)

--- a/lib/sikuli.py
+++ b/lib/sikuli.py
@@ -1,31 +1,100 @@
 import os
 import sys
+import json
+from lib.common.commonUtil import StatusRecorder
 
 
 class Sikuli():
 
-    def __init__(self, run_sikulix_cmd_path, hasal_dir):
-        self.run_sikulix_cmd_str = run_sikulix_cmd_path + " -r "
-        self.hasal_dir = hasal_dir
+    KEY_NAME_CURRENT_STATUS = 'current_status'
+    KEY_NAME_SIKULI = 'sikuli'
+    KEY_NAME_SIKULI_ARGS = 'args'
+    KEY_NAME_SIKULI_ADDITIONAL_ARGS_LIST = 'additional_args'
 
-    # hasal_dir:  DEFAULT_HASAL_DIR in environment.py
+    def __init__(self, run_sikulix_cmd_path, hasal_dir, running_statistics_file_path=''):
+        self.run_sikulix_cmd_str = run_sikulix_cmd_path + " -r "
+        self.hasal_dir = os.path.abspath(hasal_dir)
+        self.running_statistics_file_path = os.path.abspath(running_statistics_file_path)
+        self.status_recorder = None
+        self._check_status_recorder()
+
     def set_syspath(self, hasal_dir):
+        """
+        Get the Sikuli Library folder path.
+        @param hasal_dir: the Hasal root folder.
+        @return: the `lib/sikuli` folder path under Hasal root folder.
+        """
         library_path = os.path.join(hasal_dir, "lib", "sikuli")
         sys.path.append(library_path)
         return library_path
 
-    # test_name:  test_(browser)_(test_name)
-    # timestamp:  please pass in the integer generated from main python for folder record
-    def run_test(self, script_name, timestamp="0000000000", test_target="", script_dp=None, args_list=[]):
+    def _check_status_recorder(self):
+        if not os.path.isfile(self.running_statistics_file_path):
+            with open(self.running_statistics_file_path, 'w+') as f:
+                data = {
+                    self.KEY_NAME_CURRENT_STATUS: {}
+                }
+                json.dump(data, f)
+        self.status_recorder = StatusRecorder(self.running_statistics_file_path)
+
+    def _load_current_status(self):
+        if self.status_recorder:
+            return self.status_recorder.get_current_status()
+        else:
+            return {}
+
+    def _load_sikuli_status(self):
+        if self.status_recorder:
+            current_status = self._load_current_status()
+            return current_status.get(self.KEY_NAME_SIKULI, {})
+        else:
+            return {}
+
+    def set_sikuli_status(self, key, value):
+        """
+        Set up the key, value pair into status file.
+        @param key:
+        @param value:
+        @return:
+        """
+        if self.status_recorder:
+            current_status = self._load_current_status()
+            if self.KEY_NAME_SIKULI in current_status:
+                current_status[self.KEY_NAME_SIKULI].update({key: value})
+            else:
+                current_status[self.KEY_NAME_SIKULI] = {}
+                current_status[self.KEY_NAME_SIKULI].update({key: value})
+            self.status_recorder.record_current_status(current_status)
+
+    def run_test(self, script_name, case_output_name, test_target="", script_dp=None, args_list=[]):
+        """
+
+        @param script_name: <SIKULI_CASE_NAME>
+        @param case_output_name: <CASE_NAME>_<TIMESTAMP>
+        @param test_target: the target URL address.
+        @param script_dp:  specify the Sikuli cases' folder path.
+        @param args_list:
+        @return:
+        """
         if script_dp:
             script_dir_path = script_dp + os.sep + script_name + ".sikuli"
         else:
             script_path = os.path.join(self.hasal_dir, "tests")
             script_dir_path = script_path + os.sep + script_name + ".sikuli"
-        args = [str(timestamp), self.set_syspath(self.hasal_dir)]
+
+        default_args = {
+            'case_output_name': str(case_output_name),
+            'hasal_root_folder': self.hasal_dir,
+            'stat_file_path': self.running_statistics_file_path
+        }
         if test_target != "":
-            args.append(test_target)
-        args.extend(args_list)
+            default_args.update({'test_target': test_target})
+
+        self.set_sikuli_status(self.KEY_NAME_SIKULI_ARGS, default_args)
+        self.set_sikuli_status(self.KEY_NAME_SIKULI_ADDITIONAL_ARGS_LIST, args_list)
+
+        args = [self.set_syspath(self.hasal_dir), self.running_statistics_file_path]
+
         return self.run_sikulix_cmd(script_dir_path, args)
 
     def run_sikulix_cmd(self, script_dir_path, args_list=[]):

--- a/lib/sikuli/basecase.sikuli/basecase.py
+++ b/lib/sikuli/basecase.sikuli/basecase.py
@@ -58,6 +58,20 @@ class SikuliCase(object):
 
         self.additional_args = self.sikuli_status.get(self.KEY_NAME_SIKULI_ADDITIONAL_ARGS_LIST, [])
 
+    def append_to_stat_json(self, key, value):
+        """
+        Append key-value pair into stat JSON file under "current_status/sikuli" path.
+        @param key: The key name.
+        @param value: value.
+        """
+        with open(self.INPUT_STAT_FILE, 'r') as stat_fh:
+            status = json.load(stat_fh)
+            current_status = status.get(self.KEY_NAME_CURRENT_STATUS, {})
+            sikuli_status = current_status.get(self.KEY_NAME_SIKULI, {})
+            sikuli_status[key] = value
+        with open(self.INPUT_STAT_FILE, 'w') as stat_fh:
+            json.dump(status, stat_fh)
+
     def _load_addtional_args(self):
         pass
 

--- a/lib/sikuli/basecase.sikuli/basecase.py
+++ b/lib/sikuli/basecase.sikuli/basecase.py
@@ -1,0 +1,87 @@
+from sikuli import *  # NOQA
+import json
+
+
+class SikuliCase(object):
+    """
+    The base Sikuli case for Hasal.
+    It will parse sys.argv, which is [library path for running cases, running statistics file path.
+
+    After loading the stat file, it will prepare some default variables:
+    - INPUT_LIB_PATH: the library path for running cases.
+    - INPUT_STAT_FILE: the running statistics file, which is JSON format.
+    - default_args: default input arguments, which is dict object.
+    - INPUT_CASE_OUTPUT_NAME: the case output name, for example: test_firefox_foo_bar_<TIMESTAMP>
+    - INPUT_ROOT_FOLDER: the Hasal root folder.
+    - INPUT_TEST_TARGET: the test target URL address.
+    - additional_args: additional input arguments, which is array list.
+
+    Usage:
+    ```python
+        INPUT_LIB_PATH = sys.argv[1]
+        sys.path.append(INPUT_LIB_PATH)
+        import common
+        import basecase
+
+        class MyCase(basecase.SikuliCase):
+            def run(self):
+                print('Thank you 9527.')
+
+        case = MyCase(sys.argv)
+        case.run()
+    ```
+
+    """
+    KEY_NAME_CURRENT_STATUS = 'current_status'
+    KEY_NAME_SIKULI = 'sikuli'
+    KEY_NAME_SIKULI_ARGS = 'args'
+    KEY_NAME_SIKULI_ADDITIONAL_ARGS_LIST = 'additional_args'
+
+    def __init__(self, argv):
+        self.argv = argv
+        self.INPUT_LIB_PATH = argv[1]
+        self.INPUT_STAT_FILE = argv[2]
+        self._load_stat_json()
+        self._load_addtional_args()
+
+    def _load_stat_json(self):
+        with open(self.INPUT_STAT_FILE, 'r') as stat_fh:
+            status = json.load(stat_fh)
+
+        self.current_status = status.get(self.KEY_NAME_CURRENT_STATUS, {})
+        self.sikuli_status = self.current_status.get(self.KEY_NAME_SIKULI, {})
+        self.default_args = self.sikuli_status.get(self.KEY_NAME_SIKULI_ARGS, {})
+
+        self.INPUT_CASE_OUTPUT_NAME = self.default_args.get('case_output_name', '')
+        self.INPUT_ROOT_FOLDER = self.default_args.get('hasal_root_folder', '')
+        self.INPUT_TEST_TARGET = self.default_args.get('test_target', '')
+
+        self.additional_args = self.sikuli_status.get(self.KEY_NAME_SIKULI_ADDITIONAL_ARGS_LIST, [])
+
+    def _load_addtional_args(self):
+        pass
+
+    def run(self):
+        """
+        Implement the case steps by override this method.
+        """
+        raise NotImplementedError()
+
+
+class SikuliInputLatencyCase(SikuliCase):
+    """
+    The base Sikuli case for Input Latency cases.
+
+    It will loading more additional arguments:
+    - INPUT_IMG_SAMPLE_DIR_PATH = self.additional_args[0]
+    - INPUT_IMG_OUTPUT_SAMPLE_1_NAME = self.additional_args[1]
+    - INPUT_RECORD_WIDTH = self.additional_args[2]
+    - INPUT_RECORD_HEIGHT = self.additional_args[3]
+    - INPUT_TIMESTAMP_FILE_PATH = self.additional_args[4]
+    """
+    def _load_addtional_args(self):
+        self.INPUT_IMG_SAMPLE_DIR_PATH = self.additional_args[0]
+        self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME = self.additional_args[1]
+        self.INPUT_RECORD_WIDTH = self.additional_args[2]
+        self.INPUT_RECORD_HEIGHT = self.additional_args[3]
+        self.INPUT_TIMESTAMP_FILE_PATH = self.additional_args[4]

--- a/lib/sikuli/facebook.sikuli/facebook.py
+++ b/lib/sikuli/facebook.sikuli/facebook.py
@@ -59,7 +59,7 @@ class facebook(WebApp):
     def wait_for_loaded(self):
         wait(self.fb_logo, 15)
 
-    def wait_for_messenger_loaded(self):
+    def wait_for_messenger_loaded(self, similarity=0.7):
         self._wait_for_loaded(component=facebook.FACEBOOK_MESSENGER_HEADER, similarity=similarity, timeout=15)
 
     def focus_window(self):

--- a/tests/regression/amazon/test_chrome_amazon_ail_hover_related_product_thumbnail.sikuli/test_chrome_amazon_ail_hover_related_product_thumbnail.py
+++ b/tests/regression/amazon/test_chrome_amazon_ail_hover_related_product_thumbnail.sikuli/test_chrome_amazon_ail_hover_related_product_thumbnail.py
@@ -1,66 +1,71 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
+
 import shutil
 import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
-type(Key.PAGE_DOWN)
-sleep(2)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_hover_fifth_customer_watched_product(capture_width, capture_height)
+        # PRE ACTIONS
+        type(Key.PAGE_DOWN)
+        sleep(2)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_hover_fifth_customer_watched_product(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(1)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(1)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/amazon/test_chrome_amazon_ail_select_search_suggestion.sikuli/test_chrome_amazon_ail_select_search_suggestion.py
+++ b/tests/regression/amazon/test_chrome_amazon_ail_select_search_suggestion.sikuli/test_chrome_amazon_ail_select_search_suggestion.py
@@ -1,69 +1,74 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
+
 import shutil
 import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-pattern = app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        pattern = app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_search_field()
-sleep(1)
-type('m')
-app.wait_pattern_for_vanished(pattern=pattern)
-com.loop_type_key(Key.DOWN, 2, 0.5)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type_key_down_search_suggestion(capture_width, capture_height)
+        # PRE ACTIONS
+        app.click_search_field()
+        sleep(1)
+        type('m')
+        app.wait_pattern_for_vanished(pattern=pattern)
+        com.loop_type_key(Key.DOWN, 2, 0.5)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type_key_down_search_suggestion(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(1)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(1)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/amazon/test_chrome_amazon_ail_type_in_search_field.sikuli/test_chrome_amazon_ail_type_in_search_field.py
+++ b/tests/regression/amazon/test_chrome_amazon_ail_type_in_search_field.sikuli/test_chrome_amazon_ail_type_in_search_field.py
@@ -1,66 +1,71 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
+
 import shutil
 import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-pattern = app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        pattern = app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_search_field()
-sleep(1)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type('m', capture_width, capture_height)
+        # PRE ACTIONS
+        app.click_search_field()
+        sleep(1)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type('m', capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-app.wait_pattern_for_vanished(pattern)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        app.wait_pattern_for_vanished(pattern)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/amazon/test_firefox_amazon_ail_hover_related_product_thumbnail.sikuli/test_firefox_amazon_ail_hover_related_product_thumbnail.py
+++ b/tests/regression/amazon/test_firefox_amazon_ail_hover_related_product_thumbnail.sikuli/test_firefox_amazon_ail_hover_related_product_thumbnail.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
 
 import shutil
@@ -18,50 +14,58 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
-type(Key.PAGE_DOWN)
-sleep(2)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_hover_fifth_customer_watched_product(capture_width, capture_height)
+        # PRE ACTIONS
+        type(Key.PAGE_DOWN)
+        sleep(2)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_hover_fifth_customer_watched_product(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(1)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(1)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/amazon/test_firefox_amazon_ail_select_search_suggestion.sikuli/test_firefox_amazon_ail_select_search_suggestion.py
+++ b/tests/regression/amazon/test_firefox_amazon_ail_select_search_suggestion.sikuli/test_firefox_amazon_ail_select_search_suggestion.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
 
 import shutil
@@ -18,53 +14,61 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-pattern = app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        pattern = app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_search_field()
-sleep(1)
-type('m')
-app.wait_pattern_for_vanished(pattern=pattern)
-com.loop_type_key(Key.DOWN, 2, 0.5)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type_key_down_search_suggestion(capture_width, capture_height)
+        # PRE ACTIONS
+        app.click_search_field()
+        sleep(1)
+        type('m')
+        app.wait_pattern_for_vanished(pattern=pattern)
+        com.loop_type_key(Key.DOWN, 2, 0.5)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type_key_down_search_suggestion(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(1)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(1)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/amazon/test_firefox_amazon_ail_type_in_search_field.sikuli/test_firefox_amazon_ail_type_in_search_field.py
+++ b/tests/regression/amazon/test_firefox_amazon_ail_type_in_search_field.sikuli/test_firefox_amazon_ail_type_in_search_field.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import amazon
 
 import shutil
@@ -18,50 +14,58 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-com.set_mouse_delay(0)
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = amazon.Amazon()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        com.set_mouse_delay(0)
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = amazon.Amazon()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-pattern = app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        pattern = app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_search_field()
-sleep(1)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type('m', capture_width, capture_height)
+        # PRE ACTIONS
+        app.click_search_field()
+        sleep(1)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type('m', capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-app.wait_pattern_for_vanished(pattern)
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        app.wait_pattern_for_vanished(pattern)
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_click_close_chat_tab.sikuli/test_chrome_facebook_ail_click_close_chat_tab.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_click_close_chat_tab.sikuli/test_chrome_facebook_ail_click_close_chat_tab.py
@@ -1,43 +1,56 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-click(fb.right_panel_contact.targetOffset(0, 15))
-wait(fb.chat_tab_close_button)
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-hover(fb.chat_tab_close_button)
-sleep(1)
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        click(fb.right_panel_contact.targetOffset(0, 15))
+        wait(fb.chat_tab_close_button)
+
+        hover(fb.chat_tab_close_button)
+        sleep(1)
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_click_open_chat_tab.sikuli/test_chrome_facebook_ail_click_open_chat_tab.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_click_open_chat_tab.sikuli/test_chrome_facebook_ail_click_open_chat_tab.py
@@ -1,43 +1,56 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-hover(fb.right_panel_contact.targetOffset(0, 15))
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-mouseMove(fb.right_panel_contact.targetOffset(0, 50))
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
-click(fb.chat_tab_close_button)
-if not waitVanish(fb.chat_tab_close_button):
-    exit(1)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        hover(fb.right_panel_contact.targetOffset(0, 15))
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        mouseMove(fb.right_panel_contact.targetOffset(0, 50))
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        click(fb.chat_tab_close_button)
+        if not waitVanish(fb.chat_tab_close_button):
+            exit(1)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_click_open_chat_tab_emoji.sikuli/test_chrome_facebook_ail_click_open_chat_tab_emoji.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_click_open_chat_tab_emoji.sikuli/test_chrome_facebook_ail_click_open_chat_tab_emoji.py
@@ -1,46 +1,59 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-click(fb.right_panel_contact.targetOffset(0, 15))
-mouseMove(fb.right_panel_contact.targetOffset(0, 50))
-wait(fb.chat_tab_close_button)
-sleep(1)
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-# hover(fb.chat_tab_close_button)
-hover(fb.chat_tab_emoji_button)
-mouseDown(Button.LEFT)
-sleep(1)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        click(fb.right_panel_contact.targetOffset(0, 15))
+        mouseMove(fb.right_panel_contact.targetOffset(0, 50))
+        wait(fb.chat_tab_close_button)
+        sleep(1)
+
+        # hover(fb.chat_tab_close_button)
+        hover(fb.chat_tab_emoji_button)
+        mouseDown(Button.LEFT)
+        sleep(1)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_click_photo_viewer_right_arrow.sikuli/test_chrome_facebook_ail_click_photo_viewer_right_arrow.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_click_photo_viewer_right_arrow.sikuli/test_chrome_facebook_ail_click_photo_viewer_right_arrow.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-wait(fb.comment_icons, 15)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-hover(fb.comment_icons.targetOffset(-340, -40))
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        wait(fb.comment_icons, 15)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        hover(fb.comment_icons.targetOffset(-340, -40))
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_scroll_home_1_txt.sikuli/test_chrome_facebook_ail_scroll_home_1_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_scroll_home_1_txt.sikuli/test_chrome_facebook_ail_scroll_home_1_txt.py
@@ -1,41 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-# win7 threshold 0.003
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.focus_comment_box()
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.focus_comment_box()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  Scroll 1 Step')
-chrome.scroll_down(1)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  Scroll 1 Step')
+        chrome.scroll_down(1)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_type_comment_1_txt.sikuli/test_chrome_facebook_ail_type_comment_1_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_type_comment_1_txt.sikuli/test_chrome_facebook_ail_type_comment_1_txt.py
@@ -1,41 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-# win7 threshold 0.003
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.focus_comment_box()
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.focus_comment_box()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_type_composerbox_1_txt.sikuli/test_chrome_facebook_ail_type_composerbox_1_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_type_composerbox_1_txt.sikuli/test_chrome_facebook_ail_type_composerbox_1_txt.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.click_post_area_home()
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.click_post_area_home()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ail_type_message_1_txt.sikuli/test_chrome_facebook_ail_type_message_1_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ail_type_message_1_txt.sikuli/test_chrome_facebook_ail_type_message_1_txt.py
@@ -1,42 +1,55 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
-fb.wait_for_messenger_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-com.select_all()
-com.delete()
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
+        fb.wait_for_messenger_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        com.select_all()
+        com.delete()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_chrome_facebook_ft_type_composerbox_100_txt.sikuli/test_chrome_facebook_ft_type_composerbox_100_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ft_type_composerbox_100_txt.sikuli/test_chrome_facebook_ft_type_composerbox_100_txt.py
@@ -9,6 +9,7 @@ import common
 import basecase
 import facebook
 
+import string
 import shutil
 import browser
 import time

--- a/tests/regression/facebook/test_chrome_facebook_ft_type_composerbox_100_txt.sikuli/test_chrome_facebook_ft_type_composerbox_100_txt.py
+++ b/tests/regression/facebook/test_chrome_facebook_ft_type_composerbox_100_txt.sikuli/test_chrome_facebook_ft_type_composerbox_100_txt.py
@@ -1,47 +1,59 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
-import string
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
 
-chrome = browser.Chrome()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
 
-sleep(2)
-fb.click_post_area_home()
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome = browser.Chrome()
+        fb = facebook.facebook()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-com.set_type_delay(0.06)
+        sleep(2)
+        fb.click_post_area_home()
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-char_len = 100
-char_str = (string.ascii_lowercase * (char_len / 26 + 1))[:char_len]
-com.system_print('Type char')
-type(char_str)
+        com.set_type_delay(0.06)
 
-sleep(1)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+
+        char_len = 100
+        char_str = (string.ascii_lowercase * (char_len / 26 + 1))[:char_len]
+        com.system_print('Type char')
+        type(char_str)
+
+        sleep(1)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_click_close_chat_tab.sikuli/test_firefox_facebook_ail_click_close_chat_tab.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_click_close_chat_tab.sikuli/test_firefox_facebook_ail_click_close_chat_tab.py
@@ -1,43 +1,56 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-click(fb.right_panel_contact.targetOffset(0, 15))
-wait(fb.chat_tab_close_button)
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-hover(fb.chat_tab_close_button)
-sleep(1)
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        click(fb.right_panel_contact.targetOffset(0, 15))
+        wait(fb.chat_tab_close_button)
+
+        hover(fb.chat_tab_close_button)
+        sleep(1)
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_click_open_chat_tab.sikuli/test_firefox_facebook_ail_click_open_chat_tab.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_click_open_chat_tab.sikuli/test_firefox_facebook_ail_click_open_chat_tab.py
@@ -1,43 +1,56 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-hover(fb.right_panel_contact.targetOffset(0, 15))
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-mouseMove(fb.right_panel_contact.targetOffset(0, 50))
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
-click(fb.chat_tab_close_button)
-if not waitVanish(fb.chat_tab_close_button):
-    exit(1)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        hover(fb.right_panel_contact.targetOffset(0, 15))
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        mouseMove(fb.right_panel_contact.targetOffset(0, 50))
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        click(fb.chat_tab_close_button)
+        if not waitVanish(fb.chat_tab_close_button):
+            exit(1)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_click_open_chat_tab_emoji.sikuli/test_firefox_facebook_ail_click_open_chat_tab_emoji.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_click_open_chat_tab_emoji.sikuli/test_firefox_facebook_ail_click_open_chat_tab_emoji.py
@@ -1,46 +1,59 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-click(fb.right_panel_contact.targetOffset(0, 15))
-mouseMove(fb.right_panel_contact.targetOffset(0, 50))
-wait(fb.chat_tab_close_button)
-sleep(1)
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-# hover(fb.chat_tab_close_button)
-hover(fb.chat_tab_emoji_button)
-mouseDown(Button.LEFT)
-sleep(1)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        click(fb.right_panel_contact.targetOffset(0, 15))
+        mouseMove(fb.right_panel_contact.targetOffset(0, 50))
+        wait(fb.chat_tab_close_button)
+        sleep(1)
+
+        # hover(fb.chat_tab_close_button)
+        hover(fb.chat_tab_emoji_button)
+        mouseDown(Button.LEFT)
+        sleep(1)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_click_photo_viewer_right_arrow.sikuli/test_firefox_facebook_ail_click_photo_viewer_right_arrow.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_click_photo_viewer_right_arrow.sikuli/test_firefox_facebook_ail_click_photo_viewer_right_arrow.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-wait(fb.comment_icons, 15)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-# Set mouse move delay time to 0 for immediately action requirement
-Settings.MoveMouseDelay = 0
-hover(fb.comment_icons.targetOffset(-340, -40))
-mouseDown(Button.LEFT)
-capimg2 = capture(0, 0, capture_width, capture_height)
-t1 = time.time()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        wait(fb.comment_icons, 15)
 
-com.system_print('[log] Mouse Click - Button Up')
-mouseUp(Button.LEFT)
-sleep(0.1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        # Set mouse move delay time to 0 for immediately action requirement
+        Settings.MoveMouseDelay = 0
+        hover(fb.comment_icons.targetOffset(-340, -40))
+        mouseDown(Button.LEFT)
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        t1 = time.time()
+
+        com.system_print('[log] Mouse Click - Button Up')
+        mouseUp(Button.LEFT)
+        sleep(0.1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_scroll_home_1_txt.sikuli/test_firefox_facebook_ail_scroll_home_1_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_scroll_home_1_txt.sikuli/test_firefox_facebook_ail_scroll_home_1_txt.py
@@ -1,41 +1,54 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
-fb.wait_for_messenger_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.focus_comment_box()
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
+        fb.wait_for_messenger_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.focus_comment_box()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  Scroll 1 Step')
-ff.scroll_down(1)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  Scroll 1 Step')
+        ff.scroll_down(1)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_type_comment_1_txt.sikuli/test_firefox_facebook_ail_type_comment_1_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_type_comment_1_txt.sikuli/test_firefox_facebook_ail_type_comment_1_txt.py
@@ -1,41 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-# win7 threshold 0.003
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.focus_comment_box()
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.focus_comment_box()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_type_composerbox_1_txt.sikuli/test_firefox_facebook_ail_type_composerbox_1_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_type_composerbox_1_txt.sikuli/test_firefox_facebook_ail_type_composerbox_1_txt.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-fb.click_post_area_home()
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        fb.click_post_area_home()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ail_type_message_1_txt.sikuli/test_firefox_facebook_ail_type_message_1_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ail_type_message_1_txt.sikuli/test_firefox_facebook_ail_type_message_1_txt.py
@@ -1,42 +1,55 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
-fb.wait_for_messenger_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-setAutoWaitTimeout(10)
-com.select_all()
-com.delete()
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
+        fb.wait_for_messenger_loaded()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        sleep(2)
+        setAutoWaitTimeout(10)
+        com.select_all()
+        com.delete()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ft_type_composerbox_100_txt.sikuli/test_firefox_facebook_ft_type_composerbox_100_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ft_type_composerbox_100_txt.sikuli/test_firefox_facebook_ft_type_composerbox_100_txt.py
@@ -1,48 +1,59 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
-import string
 import common
+import basecase
 import facebook
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
 
-ff = browser.Firefox()
-fb = facebook.facebook()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-fb.wait_for_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
 
-sleep(2)
-fb.click_post_area_home()
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff = browser.Firefox()
+        fb = facebook.facebook()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        fb.wait_for_loaded()
 
-com.set_type_delay(0.06)
+        sleep(2)
+        fb.click_post_area_home()
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-char_len = 100
-char_str = (string.ascii_lowercase * (char_len / 26 + 1))[:char_len]
-com.system_print('Type char')
-type(char_str)
+        com.set_type_delay(0.06)
+
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+
+        char_len = 100
+        char_str = (string.ascii_lowercase * (char_len / 26 + 1))[:char_len]
+        com.system_print('Type char')
+        type(char_str)
+
+        sleep(1)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
 
 
-sleep(1)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/facebook/test_firefox_facebook_ft_type_composerbox_100_txt.sikuli/test_firefox_facebook_ft_type_composerbox_100_txt.py
+++ b/tests/regression/facebook/test_firefox_facebook_ft_type_composerbox_100_txt.sikuli/test_firefox_facebook_ft_type_composerbox_100_txt.py
@@ -9,6 +9,7 @@ import common
 import basecase
 import facebook
 
+import string
 import shutil
 import browser
 import time

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.sikuli/test_chrome_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_pagedown_10_text.sikuli/test_chrome_gdoc_ail_pagedown_10_text.py
@@ -1,37 +1,50 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
-import gdoc
 import common
+import basecase
+import gdoc
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gd = gdoc.gDoc()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gd = gdoc.gDoc()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "#PDOWN."')
-type(Key.PAGE_DOWN)
-sleep(1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "#PDOWN."')
+        type(Key.PAGE_DOWN)
+        sleep(1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.sikuli/test_chrome_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_0.sikuli/test_chrome_gdoc_ail_type_0.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
 import gdoc
+
 import shutil
 import browser
 import time
-import common
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gd = gdoc.gDoc()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gd = gdoc.gDoc()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type('a')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type('a')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.sikuli/test_chrome_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_ail_type_10p_txt.sikuli/test_chrome_gdoc_ail_type_10p_txt.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
 import gdoc
+
 import shutil
 import browser
 import time
-import common
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gd = gdoc.gDoc()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gd = gdoc.gDoc()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type('a')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type('a')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_chrome_gdoc_read_frame_throughput_scroll_1.sikuli/test_chrome_gdoc_read_frame_throughput_scroll_1.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_read_frame_throughput_scroll_1.sikuli/test_chrome_gdoc_read_frame_throughput_scroll_1.py
@@ -1,36 +1,48 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
-import browser
-import common
-import gdoc
-import shutil
-import time
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
+import gdoc
 
-com = common.General()
-chrome = browser.Chrome()
-gd = gdoc.gDoc()
+import shutil
+import browser
+import time
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-sleep(5)
-gd.wait_for_loaded()
 
-setAutoWaitTimeout(10)
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+class Case(basecase.SikuliInputLatencyCase):
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+    def run(self):
+        com = common.General()
+        chrome = browser.Chrome()
+        gd = gdoc.gDoc()
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
-gd.move_to_highlight_scroll(WHEEL_DOWN, 1)
-sleep(1)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        sleep(5)
+        gd.wait_for_loaded()
+
+        setAutoWaitTimeout(10)
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+        gd.move_to_highlight_scroll(WHEEL_DOWN, 1)
+        sleep(1)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_chrome_gdoc_read_frame_throughput_scroll_end.sikuli/test_chrome_gdoc_read_frame_throughput_scroll_end.py
+++ b/tests/regression/gdoc/test_chrome_gdoc_read_frame_throughput_scroll_end.sikuli/test_chrome_gdoc_read_frame_throughput_scroll_end.py
@@ -1,37 +1,50 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
-import browser
-import common
-import gdoc
-import shutil
-import time
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
+import gdoc
 
-com = common.General()
-chrome = browser.Chrome()
-gd = gdoc.gDoc()
+import shutil
+import browser
+import time
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-sleep(5)
-gd.wait_for_loaded()
 
-setAutoWaitTimeout(10)
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-os.remove(sample1_fp)
+class Case(basecase.SikuliInputLatencyCase):
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+    def run(self):
+        com = common.General()
+        chrome = browser.Chrome()
+        gd = gdoc.gDoc()
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
-wheel(Pattern("pics/doc_content_left_top_page_region.png").similar(0.85), WHEEL_DOWN, 100)
-sleep(0.2)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        sleep(5)
+        gd.wait_for_loaded()
+
+        setAutoWaitTimeout(10)
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        os.remove(sample1_fp)
+
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+        wheel(Pattern("pics/doc_content_left_top_page_region.png").similar(0.85), WHEEL_DOWN, 100)
+        sleep(0.2)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.sikuli/test_firefox_gdoc_ail_pagedown_10_text.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_pagedown_10_text.sikuli/test_firefox_gdoc_ail_pagedown_10_text.py
@@ -1,37 +1,50 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
-import gdoc
 import common
+import basecase
+import gdoc
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gd = gdoc.gDoc()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gd = gdoc.gDoc()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "#PDOWN."')
-type(Key.PAGE_DOWN)
-sleep(1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "#PDOWN."')
+        type(Key.PAGE_DOWN)
+        sleep(1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.sikuli/test_firefox_gdoc_ail_type_0.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_0.sikuli/test_firefox_gdoc_ail_type_0.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
 import gdoc
+
 import shutil
 import browser
 import time
-import common
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gd = gdoc.gDoc()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gd = gdoc.gDoc()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type('a')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type('a')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.sikuli/test_firefox_gdoc_ail_type_10p_txt.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_ail_type_10p_txt.sikuli/test_firefox_gdoc_ail_type_10p_txt.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
 import gdoc
+
 import shutil
 import browser
 import time
-import common
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gd = gdoc.gDoc()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gd.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gd = gdoc.gDoc()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gd.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type('a')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type('a')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_firefox_gdoc_read_frame_throughput_scroll_1.sikuli/test_firefox_gdoc_read_frame_throughput_scroll_1.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_read_frame_throughput_scroll_1.sikuli/test_firefox_gdoc_read_frame_throughput_scroll_1.py
@@ -1,36 +1,49 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
-import browser
-import common
-import gdoc
-import shutil
-import time
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
+import gdoc
 
-com = common.General()
-ff = browser.Firefox()
-gd = gdoc.gDoc()
+import shutil
+import browser
+import time
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-sleep(5)
-gd.wait_for_loaded()
 
-setAutoWaitTimeout(10)
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+class Case(basecase.SikuliInputLatencyCase):
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+    def run(self):
+        com = common.General()
+        ff = browser.Firefox()
+        gd = gdoc.gDoc()
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
-gd.move_to_highlight_scroll(WHEEL_DOWN, 1)
-sleep(1)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        sleep(5)
+        gd.wait_for_loaded()
+
+        setAutoWaitTimeout(10)
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+        gd.move_to_highlight_scroll(WHEEL_DOWN, 1)
+        sleep(1)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gdoc/test_firefox_gdoc_read_frame_throughput_scroll_end.sikuli/test_firefox_gdoc_read_frame_throughput_scroll_end.py
+++ b/tests/regression/gdoc/test_firefox_gdoc_read_frame_throughput_scroll_end.sikuli/test_firefox_gdoc_read_frame_throughput_scroll_end.py
@@ -1,37 +1,50 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
-import browser
-import common
-import gdoc
-import shutil
-import time
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
+import common
+import basecase
+import gdoc
 
-com = common.General()
-ff = browser.Firefox()
-gd = gdoc.gDoc()
+import shutil
+import browser
+import time
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-sleep(5)
-gd.wait_for_loaded()
 
-setAutoWaitTimeout(10)
-sample1_fp = os.path.join(sys.argv[4], sys.argv[5])
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
-os.remove(sample1_fp)
+class Case(basecase.SikuliInputLatencyCase):
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+    def run(self):
+        com = common.General()
+        ff = browser.Firefox()
+        gd = gdoc.gDoc()
 
-t1 = time.time()
-capimg1 = capture(0, 0, capture_width, capture_height)
-wheel(Pattern("pics/doc_content_left_top_page_region.png").similar(0.85), WHEEL_DOWN, 100)
-sleep(0.2)
-t2 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        sleep(5)
+        gd.wait_for_loaded()
+
+        setAutoWaitTimeout(10)
+        sample1_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        os.remove(sample1_fp)
+
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg1 = capture(0, 0, capture_width, capture_height)
+        wheel(Pattern("pics/doc_content_left_top_page_region.png").similar(0.85), WHEEL_DOWN, 100)
+        sleep(0.2)
+        t2 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg1, sample1_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample1_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_chrome_gmail_ail_compose_new_mail_via_keyboard.sikuli/test_chrome_gmail_ail_compose_new_mail_via_keyboard.py
+++ b/tests/regression/gmail/test_chrome_gmail_ail_compose_new_mail_via_keyboard.sikuli/test_chrome_gmail_ail_compose_new_mail_via_keyboard.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,49 +14,57 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(5)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
+        # Wait for stable
+        sleep(5)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-t1 = time.time()
-screenshot = capture(0, 0, capture_width, capture_height)
+        # PRE ACTIONS
 
-com.system_print('[log]  TYPE "c"')
-type('c')
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        t1 = time.time()
+        screenshot = capture(0, 0, capture_width, capture_height)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        com.system_print('[log]  TYPE "c"')
+        type('c')
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # Record T2
+        t2 = time.time()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_chrome_gmail_ail_open_mail.sikuli/test_chrome_gmail_ail_open_mail.py
+++ b/tests/regression/gmail/test_chrome_gmail_ail_open_mail.sikuli/test_chrome_gmail_ail_open_mail.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,45 +14,53 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(5)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
+        # Wait for stable
+        sleep(5)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-loc, screenshot, t1 = app.il_click_first_mail(capture_width, capture_height)
+        # PRE ACTIONS
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        loc, screenshot, t1 = app.il_click_first_mail(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # Record T2
+        t2 = time.time()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_chrome_gmail_ail_type_in_reply_field.sikuli/test_chrome_gmail_ail_type_in_reply_field.py
+++ b/tests/regression/gmail/test_chrome_gmail_ail_type_in_reply_field.sikuli/test_chrome_gmail_ail_type_in_reply_field.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,53 +14,61 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Chrome()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Chrome()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_first_mail()
-sleep(2)
-app.click_reply_btn()
-sleep(3)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type('a', capture_width, capture_height, wait_component=app.GMAIL_SEND)
+        # PRE ACTIONS
+        app.click_first_mail()
+        sleep(2)
+        app.click_reply_btn()
+        sleep(3)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type('a', capture_width, capture_height, wait_component=app.GMAIL_SEND)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(2)
-app.click_reply_del_btn()
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(2)
+        app.click_reply_del_btn()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_firefox_gmail_ail_compose_new_mail_via_keyboard.sikuli/test_firefox_gmail_ail_compose_new_mail_via_keyboard.py
+++ b/tests/regression/gmail/test_firefox_gmail_ail_compose_new_mail_via_keyboard.sikuli/test_firefox_gmail_ail_compose_new_mail_via_keyboard.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,49 +14,57 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(5)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
+        # Wait for stable
+        sleep(5)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-t1 = time.time()
-screenshot = capture(0, 0, capture_width, capture_height)
+        # PRE ACTIONS
 
-com.system_print('[log]  TYPE "c"')
-type('c')
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        t1 = time.time()
+        screenshot = capture(0, 0, capture_width, capture_height)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        com.system_print('[log]  TYPE "c"')
+        type('c')
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # Record T2
+        t2 = time.time()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_firefox_gmail_ail_open_mail.sikuli/test_firefox_gmail_ail_open_mail.py
+++ b/tests/regression/gmail/test_firefox_gmail_ail_open_mail.sikuli/test_firefox_gmail_ail_open_mail.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,45 +14,53 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(5)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
+        # Wait for stable
+        sleep(5)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-loc, screenshot, t1 = app.il_click_first_mail(capture_width, capture_height)
+        # PRE ACTIONS
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        loc, screenshot, t1 = app.il_click_first_mail(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # Record T2
+        t2 = time.time()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_firefox_gmail_ail_reply_mail.sikuli/test_firefox_gmail_ail_reply_mail.py
+++ b/tests/regression/gmail/test_firefox_gmail_ail_reply_mail.sikuli/test_firefox_gmail_ail_reply_mail.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,47 +14,55 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_first_mail()
-sleep(3)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-loc, screenshot, t1 = app.il_click_reply_btn(capture_width, capture_height)
+        # PRE ACTIONS
+        app.click_first_mail()
+        sleep(3)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        loc, screenshot, t1 = app.il_click_reply_btn(capture_width, capture_height)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # Record T2
+        t2 = time.time()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gmail/test_firefox_gmail_ail_type_in_reply_field.sikuli/test_firefox_gmail_ail_type_in_reply_field.py
+++ b/tests/regression/gmail/test_firefox_gmail_ail_type_in_reply_field.sikuli/test_firefox_gmail_ail_type_in_reply_field.py
@@ -1,16 +1,12 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-INPUT_LIB_PATH = sys.argv[2]
-INPUT_TEST_TARGET = sys.argv[3]
-INPUT_IMG_SAMPLE_DIR_PATH = sys.argv[4]
-INPUT_IMG_OUTPUT_SAMPLE_1_NAME = sys.argv[5]
-INPUT_RECORD_WIDTH = sys.argv[6]
-INPUT_RECORD_HEIGHT = sys.argv[7]
-INPUT_TIMESTAMP_FILE_PATH = sys.argv[8]
 
+INPUT_LIB_PATH = sys.argv[1]
 sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gmail
 
 import shutil
@@ -18,53 +14,61 @@ import browser
 import time
 
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(False)
-Settings.MoveMouseDelay = 0
+class Case(basecase.SikuliInputLatencyCase):
 
-# Prepare
-app = gmail.gMail()
-sample2_file_path = os.path.join(INPUT_IMG_SAMPLE_DIR_PATH, INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
-sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
-capture_width = int(INPUT_RECORD_WIDTH)
-capture_height = int(INPUT_RECORD_HEIGHT)
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(False)
+        Settings.MoveMouseDelay = 0
 
-# Launch browser
-my_browser = browser.Firefox()
+        # Prepare
+        app = gmail.gMail()
+        sample2_file_path = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH,
+                                         self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
+        sample2_file_path = sample2_file_path.replace(os.path.splitext(sample2_file_path)[1], '.png')
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-# Access link and wait
-my_browser.clickBar()
-my_browser.enterLink(INPUT_TEST_TARGET)
-app.wait_for_loaded()
+        # Launch browser
+        my_browser = browser.Firefox()
 
-# Wait for stable
-sleep(2)
+        # Access link and wait
+        my_browser.clickBar()
+        my_browser.enterLink(self.INPUT_TEST_TARGET)
+        app.wait_for_loaded()
 
-# PRE ACTIONS
-app.click_first_mail()
-sleep(2)
-app.click_reply_btn()
-sleep(3)
+        # Wait for stable
+        sleep(2)
 
-# Record T1, and capture the snapshot image
-# Input Latency Action
-screenshot, t1 = app.il_type('a', capture_width, capture_height, wait_component=app.GMAIL_SEND)
+        # PRE ACTIONS
+        app.click_first_mail()
+        sleep(2)
+        app.click_reply_btn()
+        sleep(3)
 
-# In normal condition, a should appear within 100ms,
-# but if lag happened, that could lead the show up after 100 ms,
-# and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        # Record T1, and capture the snapshot image
+        # Input Latency Action
+        screenshot, t1 = app.il_type('a', capture_width, capture_height, wait_component=app.GMAIL_SEND)
 
-# Record T2
-t2 = time.time()
+        # In normal condition, a should appear within 100ms,
+        # but if lag happened, that could lead the show up after 100 ms,
+        # and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
 
-# POST ACTIONS
-sleep(2)
-app.click_reply_del_btn()
+        # Record T2
+        t2 = time.time()
 
-# Write timestamp
-com.updateJson({'t1': t1, 't2': t2}, INPUT_TIMESTAMP_FILE_PATH)
+        # POST ACTIONS
+        sleep(2)
+        app.click_reply_del_btn()
 
-# Write the snapshot image
-shutil.move(screenshot, sample2_file_path)
+        # Write timestamp
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+
+        # Write the snapshot image
+        shutil.move(screenshot, sample2_file_path)
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_chrome_gsearch_ail_select_image_cat.sikuli/test_chrome_gsearch_ail_select_image_cat.py
+++ b/tests/regression/gsearch/test_chrome_gsearch_ail_select_image_cat.sikuli/test_chrome_gsearch_ail_select_image_cat.py
@@ -1,42 +1,55 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
-com.set_mouse_delay(0)
 
-chrome = browser.Chrome()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_gimage_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
+        com.set_mouse_delay(0)
 
-sleep(2)
-gs.hover_result_image(1, 1)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome = browser.Chrome()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gimage_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.hover_result_image(1, 1)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-mouseDown(Button.LEFT)
-com.system_print('[log]  Mouse up on first image')
-mouseUp(Button.LEFT)
-# gs.click_result_image(1, 1)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
-com.set_mouse_delay()
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        mouseDown(Button.LEFT)
+        com.system_print('[log]  Mouse up on first image')
+        mouseUp(Button.LEFT)
+        # gs.click_result_image(1, 1)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        com.set_mouse_delay()
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_chrome_gsearch_ail_select_search_suggestion.sikuli/test_chrome_gsearch_ail_select_search_suggestion.py
+++ b/tests/regression/gsearch/test_chrome_gsearch_ail_select_search_suggestion.sikuli/test_chrome_gsearch_ail_select_search_suggestion.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_gsearch_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-gs.focus_search_inputbox()
-type("mozilla")
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome = browser.Chrome()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gsearch_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.focus_search_inputbox()
+        type("mozilla")
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  Key Down')
-type(Key.DOWN)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  Key Down')
+        type(Key.DOWN)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_chrome_gsearch_ail_type_searchbox.sikuli/test_chrome_gsearch_ail_type_searchbox.py
+++ b/tests/regression/gsearch/test_chrome_gsearch_ail_type_searchbox.sikuli/test_chrome_gsearch_ail_type_searchbox.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_gsearch_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-gs.focus_search_inputbox()
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        chrome = browser.Chrome()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gsearch_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.focus_search_inputbox()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_firefox_gsearch_ail_select_image_cat.sikuli/test_firefox_gsearch_ail_select_image_cat.py
+++ b/tests/regression/gsearch/test_firefox_gsearch_ail_select_image_cat.sikuli/test_firefox_gsearch_ail_select_image_cat.py
@@ -1,42 +1,55 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
-com.set_mouse_delay(0)
 
-ff = browser.Firefox()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_gimage_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
+        com.set_mouse_delay(0)
 
-sleep(2)
-gs.hover_result_image(1, 1)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff = browser.Firefox()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gimage_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.hover_result_image(1, 1)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-mouseDown(Button.LEFT)
-com.system_print('[log]  Mouse up on first image')
-mouseUp(Button.LEFT)
-# gs.click_result_image(1, 1)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
-com.set_mouse_delay()
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        mouseDown(Button.LEFT)
+        com.system_print('[log]  Mouse up on first image')
+        mouseUp(Button.LEFT)
+        # gs.click_result_image(1, 1)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        com.set_mouse_delay()
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_firefox_gsearch_ail_select_search_suggestion.sikuli/test_firefox_gsearch_ail_select_search_suggestion.py
+++ b/tests/regression/gsearch/test_firefox_gsearch_ail_select_search_suggestion.sikuli/test_firefox_gsearch_ail_select_search_suggestion.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_gsearch_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-gs.focus_search_inputbox()
-type("mozilla")
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff = browser.Firefox()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gsearch_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.focus_search_inputbox()
+        type("mozilla")
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  Key Down')
-type(Key.DOWN)
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  Key Down')
+        type(Key.DOWN)
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsearch/test_firefox_gsearch_ail_type_searchbox.sikuli/test_firefox_gsearch_ail_type_searchbox.py
+++ b/tests/regression/gsearch/test_firefox_gsearch_ail_type_searchbox.sikuli/test_firefox_gsearch_ail_type_searchbox.py
@@ -1,38 +1,51 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsearch
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gs = gsearch.Gsearch()
+class Case(basecase.SikuliInputLatencyCase):
 
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_gsearch_loaded()
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(2)
-gs.focus_search_inputbox()
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+        ff = browser.Firefox()
+        gs = gsearch.Gsearch()
 
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_gsearch_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        sleep(2)
+        gs.focus_search_inputbox()
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "a"')
-type("a")
-sleep(1)
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
+
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "a"')
+        type("a")
+        sleep(1)
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.sikuli/test_chrome_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_pagedown_400_text.sikuli/test_chrome_gsheet_ail_pagedown_400_text.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gs = gsheet.gSheet()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gs = gsheet.gSheet()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "#PDOWN."')
-type(Key.PAGE_DOWN)
-sleep(1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "#PDOWN."')
+        type(Key.PAGE_DOWN)
+        sleep(1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.sikuli/test_chrome_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_0.sikuli/test_chrome_gsheet_ail_type_0.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
-import gsheet
 import common
+import basecase
+import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gs = gsheet.gSheet()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gs = gsheet.gSheet()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "9"')
-type('9')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "9"')
+        type('9')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.sikuli/test_chrome_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_chrome_gsheet_ail_type_400.sikuli/test_chrome_gsheet_ail_type_400.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
-import gsheet
 import common
+import basecase
+import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-chrome = browser.Chrome()
-gs = gsheet.gSheet()
-chrome.clickBar()
-chrome.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        chrome = browser.Chrome()
+        gs = gsheet.gSheet()
+        chrome.clickBar()
+        chrome.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "9"')
-type('9')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "9"')
+        type('9')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.sikuli/test_firefox_gsheet_ail_pagedown_400_text.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_pagedown_400_text.sikuli/test_firefox_gsheet_ail_pagedown_400_text.py
@@ -1,39 +1,52 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gs = gsheet.gSheet()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gs = gsheet.gSheet()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "#PDOWN."')
-type(Key.PAGE_DOWN)
-sleep(1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "#PDOWN."')
+        type(Key.PAGE_DOWN)
+        sleep(1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.sikuli/test_firefox_gsheet_ail_type_0.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_0.sikuli/test_firefox_gsheet_ail_type_0.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gs = gsheet.gSheet()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gs = gsheet.gSheet()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "9"')
-type('9')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "9"')
+        type('9')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()

--- a/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.sikuli/test_firefox_gsheet_ail_type_400.py
+++ b/tests/regression/gsheet/test_firefox_gsheet_ail_type_400.sikuli/test_firefox_gsheet_ail_type_400.py
@@ -1,40 +1,53 @@
 # if you are putting your test script folders under {git project folder}/tests/, it will work fine.
 # otherwise, you either add it to system path before you run or hard coded it in here.
-sys.path.append(sys.argv[2])
+
+INPUT_LIB_PATH = sys.argv[1]
+sys.path.append(INPUT_LIB_PATH)
+
 import os
 import common
+import basecase
 import gsheet
+
 import shutil
 import browser
 import time
 
-# Disable Sikuli action and info log
-com = common.General()
-com.infolog_enable(0)
 
-ff = browser.Firefox()
-gs = gsheet.gSheet()
-ff.clickBar()
-ff.enterLink(sys.argv[3])
-gs.wait_for_loaded()
+class Case(basecase.SikuliInputLatencyCase):
 
-setAutoWaitTimeout(10)
-sample2_fp = os.path.join(sys.argv[4], sys.argv[5].replace('sample_1', 'sample_2'))
+    def run(self):
+        # Disable Sikuli action and info log
+        com = common.General()
+        com.infolog_enable(0)
 
-sleep(5)
-click(gs.gsheet_1st_cell)
-sleep(2)
-capture_width = int(sys.argv[6])
-capture_height = int(sys.argv[7])
+        ff = browser.Firefox()
+        gs = gsheet.gSheet()
+        ff.clickBar()
+        ff.enterLink(self.INPUT_TEST_TARGET)
+        gs.wait_for_loaded()
 
-t1 = time.time()
-capimg2 = capture(0, 0, capture_width, capture_height)
+        setAutoWaitTimeout(10)
+        sample2_fp = os.path.join(self.INPUT_IMG_SAMPLE_DIR_PATH, self.INPUT_IMG_OUTPUT_SAMPLE_1_NAME.replace('sample_1', 'sample_2'))
 
-com.system_print('[log]  TYPE "9"')
-type('9')
-# In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
-sleep(0.1)
+        sleep(5)
+        click(gs.gsheet_1st_cell)
+        sleep(2)
+        capture_width = int(self.INPUT_RECORD_WIDTH)
+        capture_height = int(self.INPUT_RECORD_HEIGHT)
 
-t2 = time.time()
-com.updateJson({'t1': t1, 't2': t2}, sys.argv[8])
-shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+        t1 = time.time()
+        capimg2 = capture(0, 0, capture_width, capture_height)
+
+        com.system_print('[log]  TYPE "9"')
+        type('9')
+        # In normal condition, a should appear within 100ms, but if lag happened, that could lead the show up after 100 ms, and that will cause the calculation of AIL much smaller than expected.
+        sleep(0.1)
+
+        t2 = time.time()
+        com.updateJson({'t1': t1, 't2': t2}, self.INPUT_TIMESTAMP_FILE_PATH)
+        shutil.move(capimg2, sample2_fp.replace(os.path.splitext(sample2_fp)[1], '.png'))
+
+
+case = Case(sys.argv)
+case.run()


### PR DESCRIPTION
Adding the `SikuliCase` under `lib.sikuli.basecase` for Sikuli **Input Latency** and **Frame Throughput** cases.
Adding the parameters into `running_statistics_file` in `lib.sikuli.Sikuli`.

The args_list can be stored into JSON file due to Array is an ordered sequence of sero or more values.
Reference: RFC 7159 http://www.rfc-editor.org/rfc/rfc7159.txt

**Verify list**
- [x] amazon IL (@ShakoHo)
- [x] facebook IL+FT (@ShakoHo) partially missing some png files and variable, see #722
- [x] gdoc IL+FT (@askeing)
- [x] gmail IL (@askeing)
- [x] gsearch IL (@ShakoHo)
- [x] gsheet IL (@askeing)

After landing this patch, the **Page Load** cases do **NOT** work anymore.
If you have to run Page Load cases, you should modify them to new design.
Ref: #717
