### PR TITLE
Modify the Sikuli Base Case class for skipping some runtime error

### DIFF
--- a/lib/sikuli/basecase.sikuli/basecase.py
+++ b/lib/sikuli/basecase.sikuli/basecase.py
@@ -7,6 +7,8 @@ class SikuliCase(object):
     The base Sikuli case for Hasal.
     It will parse sys.argv, which is [library path for running cases, running statistics file path.
 
+    Please implement your "run()" method for running your steps.
+
     After loading the stat file, it will prepare some default variables:
     - INPUT_LIB_PATH: the library path for running cases.
     - INPUT_STAT_FILE: the running statistics file, which is JSON format.
@@ -74,12 +76,6 @@ class SikuliCase(object):
 
     def _load_addtional_args(self):
         pass
-
-    def run(self):
-        """
-        Implement the case steps by override this method.
-        """
-        raise NotImplementedError()
 
 
 class SikuliInputLatencyCase(SikuliCase):


### PR DESCRIPTION
@MikeLien found that sometimes the running instance will executes the original method to raise Exception.

failed case
```bash
2017-05-25 15:09 INFO [lib.converter.cv2Converter.generate_result] ==== FPS from video header: 1000.0====
E2017-05-25 15:09 INFO [lib\common\commonUtil.pyc.is_video_recording] Enabled Recorder: AvconvProfiler
2017-05-25 15:09 INFO [lib.common.windowController._close_window_win32_cb] Found [Nightly] and closed the window.
```

passed case
```bash
2017-05-25 14:59 INFO [lib.converter.cv2Converter.generate_result] ==== FPS from video header: 1000.0====
+++ running this Java
java version "1.8.0_131"
Java(TM) SE Runtime Environment (build 1.8.0_131-b11)
Java HotSpot(TM) 64-Bit Server VM (build 25.131-b11, mixed mode)
+++ trying to run SikuliX
+++ using: -Xms64M -Xmx512M -Dfile.encoding=UTF-8 -Dsikuli.FromCommandLine -jar c:\Users\user\Hasal\thirdParty\sikulix.j
ar -r tests\regression\gmail\test_firefox_gmail_ail_open_mail.sikuli --args "c:\Users\user\Hasal\lib\sikuli" "c:\Users\u
ser\Hasal\running_statistics.json"
Click First Mail
2017-05-25 15:00 INFO [lib\common\commonUtil.pyc.is_video_recording] Enabled Recorder: AvconvProfiler
2017-05-25 15:00 INFO [lib.common.windowController._close_window_win32_cb] Found [Nightly] and closed the window.
```