### PR TITLE
disable hint box

### DIFF
--- a/configs/firefox/default.json
+++ b/configs/firefox/default.json
@@ -25,7 +25,9 @@
     "datareporting.healthreport.service.firstRun": false,
     "general.useragent.locale": "en-US",
     "intl.accept_languages": "en-US, en",
-    "gfx.downloadable_fonts.otl_validation": false
+    "gfx.downloadable_fonts.otl_validation": false,
+    "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/geckoprofiler.json
+++ b/configs/firefox/geckoprofiler.json
@@ -25,7 +25,9 @@
     "datareporting.healthreport.service.firstRun": false,
     "general.useragent.locale": "en-US",
     "intl.accept_languages": "en-US, en",
-    "gfx.downloadable_fonts.otl_validation": false
+    "gfx.downloadable_fonts.otl_validation": false,
+    "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/har.json
+++ b/configs/firefox/har.json
@@ -29,7 +29,9 @@
     "extensions.netmonitor.har.enableAutomation": true,
     "general.useragent.locale": "en-US",
     "intl.accept_languages": "en-US, en",
-    "gfx.downloadable_fonts.otl_validation": false
+    "gfx.downloadable_fonts.otl_validation": false,
+    "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/obs_on_windows.json
+++ b/configs/firefox/obs_on_windows.json
@@ -25,7 +25,9 @@
     "datareporting.healthreport.service.firstRun": false,
     "general.useragent.locale": "en-US",
     "intl.accept_languages": "en-US, en",
-    "gfx.downloadable_fonts.otl_validation": false
+    "gfx.downloadable_fonts.otl_validation": false,
+    "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
   },
   "profile_files": {
     "DisableStatusBar": {


### PR DESCRIPTION
This should be able to dismiss the most up-to-date hint box in Nightly browser.
@ShakoHo @MikeLien @askeing r?