### PR TITLE
add file exist check before rename firefox binary path

### DIFF
--- a/agent/hasalTask.py
+++ b/agent/hasalTask.py
@@ -165,7 +165,8 @@ class HasalTask(object):
                 else:
                     shutil.rmtree(firefox_fp)
         else:
-            os.rename(firefox_fp, backup_path)
+            if os.path.exists(firefox_fp):
+                os.rename(firefox_fp, backup_path)
 
         if sys.platform == "linux2":
             src_link = os.path.join(os.getcwd(), "firefox", "firefox")

--- a/agent/hasalTask.py
+++ b/agent/hasalTask.py
@@ -157,6 +157,8 @@ class HasalTask(object):
         else:
             firefox_fp = self.FIREFOX_BIN_MAC_FP
         # Create and check backup
+        # Move default firefox to backup folder, and we want to always keep one copy of default firefox package,
+        # so we won't always replace the backup one.
         backup_path = firefox_fp + ".bak"
         if os.path.exists(backup_path):
             if os.path.exists(firefox_fp):


### PR DESCRIPTION
we can use this patch to avoid some machine environment not contain firefox in default path
@askeing @ypwalter @MikeLien r?