### PR TITLE
avoiding new unsent crash report notification bar

### DIFF
--- a/configs/firefox/default.json
+++ b/configs/firefox/default.json
@@ -27,7 +27,10 @@
     "intl.accept_languages": "en-US, en",
     "gfx.downloadable_fonts.otl_validation": false,
     "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
-    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0,
+    "browser.crashReports.unsubmittedCheck.enabled": false,
+    "browser.tabs.crashReporting.sendReport": false,
+    "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/geckoprofiler.json
+++ b/configs/firefox/geckoprofiler.json
@@ -27,7 +27,10 @@
     "intl.accept_languages": "en-US, en",
     "gfx.downloadable_fonts.otl_validation": false,
     "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
-    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0,
+    "browser.crashReports.unsubmittedCheck.enabled": false,
+    "browser.tabs.crashReporting.sendReport": false,
+    "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/har.json
+++ b/configs/firefox/har.json
@@ -31,7 +31,10 @@
     "intl.accept_languages": "en-US, en",
     "gfx.downloadable_fonts.otl_validation": false,
     "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
-    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0,
+    "browser.crashReports.unsubmittedCheck.enabled": false,
+    "browser.tabs.crashReporting.sendReport": false,
+    "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/obs_on_windows.json
+++ b/configs/firefox/obs_on_windows.json
@@ -27,7 +27,10 @@
     "intl.accept_languages": "en-US, en",
     "gfx.downloadable_fonts.otl_validation": false,
     "browser.urlbar.daysBeforeHidingSuggestionsPrompt": 0,
-    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0
+    "browser.urlbar.timesBeforeHidingSuggestionsHint": 0,
+    "browser.crashReports.unsubmittedCheck.enabled": false,
+    "browser.tabs.crashReporting.sendReport": false,
+    "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false
   },
   "profile_files": {
     "DisableStatusBar": {


### PR DESCRIPTION
There is a new unsent crash report notification bar from new firefox nightly. This should prevent us from having issues.

@ShakoHo @MikeLien @askeing r?