### PR TITLE
Modify the `get_value_from_config` to raise warning only when value is None

### DIFF
--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -493,7 +493,7 @@ class CommonUtil(object):
     @staticmethod
     def get_value_from_config(config, key):
         value = config.get(key)
-        if not value:
-            logger.warn('There is no {key} in {config} config file.'.format(key=key,
-                                                                            config=config))
+        if value is None:
+            logger.warn('There is no {key} in {config} config file (or the value is None).'.format(key=key,
+                                                                                                   config=config))
         return value


### PR DESCRIPTION
@MikeLien found there are some warning message when the value is `False`.

After tracing the code, when the value is one of `False`, `''`, `0`, and so on.
So we have to check the value, raising the warning message when it is None.