### PR TITLE
Make sure the video file is opened and ready for converting images

### DIFF
--- a/lib/converter/cv2Converter.py
+++ b/lib/converter/cv2Converter.py
@@ -15,6 +15,19 @@ class Cv2Converter(object):
         search_range = []
         return_result = {}
         vidcap = cv2.VideoCapture(input_data['video_fp'])
+
+        # make sure the video file is opened, ready for convert to images
+        for _ in range(60):
+            if vidcap.isOpened():
+                break
+            else:
+                time.sleep(1)
+                vidcap = cv2.VideoCapture(input_data['video_fp'])
+        if not vidcap.isOpened():
+            logger.debug('Video file cannot open: {}'.format(input_data['video_fp']))
+            return None
+        logger.debug('Video file is opened: {}'.format(input_data['video_fp']))
+
         if hasattr(cv2, 'CAP_PROP_FPS'):
             header_fps = vidcap.get(cv2.CAP_PROP_FPS)
         else:


### PR DESCRIPTION
After getting the `cv2.VideoCapture` object, we have to check the `isOpened()`
The `vidcap.isOpened()` will be `False` when video file is not ready.
And the `vidcap.read()` will return `(False, None)`.

Ref: #520