### PR TITLE
modify for get revert timestamp for video usage

### DIFF
--- a/configs/index/runtimeDctGenerator.json
+++ b/configs/index/runtimeDctGenerator.json
@@ -16,17 +16,20 @@
   "platform-dep-settings"   : {
     "darwin":{
       "default": {
-        "video-recording-fps": 60
+        "video-recording-fps": 60,
+        "search-margin": 10
       }
     },
     "win32":{
       "default": {
-        "video-recording-fps": 60
+        "video-recording-fps": 60,
+        "search-margin": 10
       }
     },
     "linux2":{
       "default": {
-        "video-recording-fps": 60
+        "video-recording-fps": 60,
+        "search-margin": 10
       }
     }
   }

--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -497,3 +497,11 @@ class CommonUtil(object):
             logger.warn('There is no {key} in {config} config file (or the value is None).'.format(key=key,
                                                                                                    config=config))
         return value
+
+    @staticmethod
+    def update_json(input_data, filename, mode="r+"):
+        with open(filename, mode) as fh:
+            origin_data = json.load(fh)
+            origin_data.update(input_data)
+            fh.seek(0)
+            fh.write(json.dumps(origin_data))

--- a/lib/converter/cv2Converter.py
+++ b/lib/converter/cv2Converter.py
@@ -32,6 +32,14 @@ class Cv2Converter(object):
             header_fps = vidcap.get(cv2.CAP_PROP_FPS)
         else:
             header_fps = vidcap.get(cv2.cv.CV_CAP_PROP_FPS)
+
+        if hasattr(cv2, 'CV_CAP_PROP_FRAME_COUNT'):
+            total_frames = int(vidcap.get(cv2.CV_CAP_PROP_FRAME_COUNT))
+        else:
+            total_frames = int(vidcap.get(cv2.cv.CV_CAP_PROP_FRAME_COUNT))
+        total_frames = 0 if total_frames <= 0 else total_frames
+        logger.debug("Total Frames: {}".format(total_frames))
+
         if "current_fps" not in input_data:
             input_data['current_fps'] = header_fps
             logger.info('==== FPS from video header: ' + str(input_data['current_fps']) + '====')
@@ -39,7 +47,7 @@ class Cv2Converter(object):
             logger.info('==== FPS from log file: ' + str(input_data['current_fps']) + '====')
         real_time_shift = float(header_fps) / input_data['current_fps']
         if "exec_timestamp_list" in input_data:
-            search_range = get_search_range(input_data['exec_timestamp_list'], input_data['current_fps'])
+            search_range = get_search_range(input_data['exec_timestamp_list'], input_data['current_fps'], total_frames, input_data['search_margin'])
 
         if "output_image_name" in input_data:
             if os.path.exists(input_data['output_img_dp']) is False:

--- a/lib/helper/generatorHelper.py
+++ b/lib/helper/generatorHelper.py
@@ -56,13 +56,13 @@ def run_modules(module_settings, module_data):
     return module_result
 
 
-def get_json_data(input_fp, initial_timestamp_name):
+def get_timestamp_json_data(input_fp, initial_timestamp_name):
     # TODO: need to support multiple sample timestamps in the future
     try:
         with open(input_fp, "r") as fh:
             timestamp = json.load(fh)
             logger.debug('Load timestamps: %s' % timestamp)
-        timestamp_list = map(float, [timestamp[initial_timestamp_name], timestamp["t1"], timestamp["t2"]])
+        timestamp_list = map(float, [timestamp[initial_timestamp_name], timestamp["t1"], timestamp["t2"], timestamp["end"]])
     except Exception as e:
         logger.error(e)
         logger.error('Make timestamp list be empty.')
@@ -97,7 +97,7 @@ def calculate(env, global_config, exec_config, index_config, firefox_config, onl
     # will do the analyze after validate pass
     validate_result = validate_data(validator_settings, validator_data)
 
-    exec_timestamp_list = get_json_data(env.DEFAULT_TIMESTAMP, env.INITIAL_TIMESTAMP_NAME)
+    exec_timestamp_list = get_timestamp_json_data(env.DEFAULT_TIMESTAMP, env.INITIAL_TIMESTAMP_NAME)
     if validate_result['validate_result']:
         if not validate_result.get(global_config['default-fps-validator-name']):
             current_fps_value = index_config['video-recording-fps']
@@ -110,7 +110,8 @@ def calculate(env, global_config, exec_config, index_config, firefox_config, onl
             index_config['image-converter-name']: {'video_fp': env.video_output_fp, 'output_img_dp': env.img_output_dp,
                                                    'convert_fmt': index_config['image-converter-format'],
                                                    'current_fps': current_fps_value,
-                                                   'exec_timestamp_list': exec_timestamp_list}}
+                                                   'exec_timestamp_list': exec_timestamp_list,
+                                                   'search_margin': index_config['search-margin']}}
         converter_result = run_modules(converter_settings, converter_data[index_config['image-converter-name']])
 
         generator_name = index_config['module-name']

--- a/lib/profiler/avconvProfiler.py
+++ b/lib/profiler/avconvProfiler.py
@@ -38,3 +38,6 @@ class AvconvProfiler(BaseProfiler):
             subprocess.Popen("taskkill /IM ffmpeg.exe /T /F", shell=True)
         else:
             self.process.send_signal(3)
+        timestamp = time.time()
+        timestamp_info = {'end': timestamp}
+        CommonUtil.update_json(timestamp_info, self.env.DEFAULT_TIMESTAMP)

--- a/lib/profiler/obsProfiler.py
+++ b/lib/profiler/obsProfiler.py
@@ -214,6 +214,9 @@ class ObsProfiler(BaseProfiler):
             # stop recording
             self.pywin32_ctrl_q()
             self.pywin32_return()
+            timestamp = time.time()
+            timestamp_info = {'end': timestamp}
+            CommonUtil.update_json(timestamp_info, self.env.DEFAULT_TIMESTAMP)
             time.sleep(2)
 
             # get latest video file for obs video output dir


### PR DESCRIPTION
**WIP**

We record timestamps for video initial and actions from t1 and t2 for following analysis and calculation like below:
```
-------o-----------o--------o------
    initial       t1       t2        (timestamps)
```

But since we don't know the exactly start point for video start (currently we wait video file exist for [ffmpeg recording](https://github.com/Mozilla-TWQA/Hasal/blob/dev/lib/profiler/avconvProfiler.py#L29-L34) and [obs recording](https://github.com/Mozilla-TWQA/Hasal/blob/dev/lib/profiler/obsProfiler.py#L163-L174)), we may record incorrect initial timestamp while computer running slower.

A new idea is that we assume video recording termination will faster then starting video recording, thus we use another time stamp as below:
```
initial
|------------------o--------o------o--
                  t1       t2     end  (timestamps)
```

We can use total frames of video and recorded timestamps to calculate the duration from actual `initial time` to `t1` and `t2` and it might be much precise.

