### PR TITLE
make crashReports autoSubmit enabled

### DIFF
--- a/configs/firefox/default.json
+++ b/configs/firefox/default.json
@@ -31,6 +31,7 @@
     "browser.crashReports.unsubmittedCheck.enabled": false,
     "browser.tabs.crashReporting.sendReport": false,
     "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false,
+    "browser.crashReports.unsubmittedCheck.autoSubmit": true,
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,

--- a/configs/firefox/geckoprofiler.json
+++ b/configs/firefox/geckoprofiler.json
@@ -31,6 +31,7 @@
     "browser.crashReports.unsubmittedCheck.enabled": false,
     "browser.tabs.crashReporting.sendReport": false,
     "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false,
+    "browser.crashReports.unsubmittedCheck.autoSubmit": true,
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,

--- a/configs/firefox/har.json
+++ b/configs/firefox/har.json
@@ -35,6 +35,7 @@
     "browser.crashReports.unsubmittedCheck.enabled": false,
     "browser.tabs.crashReporting.sendReport": false,
     "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false,
+    "browser.crashReports.unsubmittedCheck.autoSubmit": true,
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,

--- a/configs/firefox/obs_on_windows.json
+++ b/configs/firefox/obs_on_windows.json
@@ -31,6 +31,7 @@
     "browser.crashReports.unsubmittedCheck.enabled": false,
     "browser.tabs.crashReporting.sendReport": false,
     "dom.ipc.plugins.flash.subprocess.crashreporter.enabled": false,
+    "browser.crashReports.unsubmittedCheck.autoSubmit": true,
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,


### PR DESCRIPTION
@ShakoHo @askeing @MikeLien r?
Firefox doesn't take in disabling of crash reports notification. We now enable auto-submission to prevent from further issues.