### PR TITLE
removal of mitmproxy installation in bootstrap (pyasn)

### DIFF
--- a/bootstrap.bat
+++ b/bootstrap.bat
@@ -289,7 +289,7 @@ IF "%APPVEYOR%"=="True" (
     ECHO [INFO] Setup in virtualenv
     activate env-python
     pip install pywin32-ctypes==0.0.1
-    pip install coverage mitmproxy
+    pip install coverage
     pip install thirdParty\opencv_python-2.4.13-cp27-cp27m-win32.whl
     python setup.py install
 ) ELSE (


### PR DESCRIPTION
In latest RC release, Appveyor failed due to collision of python package requirement. I planned to remove mitmproxy installation in Appveyor for now.

mitmproxy installation requires `pyasn >0.1.9 <0.2`
However, simplejson requires `pyasn==0.3.2`

mitmproxy installation is currently not a concern in Appveyor. It is removed in this commit and under test. If it pass the AppVeyor run, I hope that we will use this bootstrap config for now.

