### PR TITLE
Adding Pulse "mgt" topic for sending Agent response to Trigger

### DIFF
--- a/configs/ejenti/trigger_config.json
+++ b/configs/ejenti/trigger_config.json
@@ -6,7 +6,7 @@
       "enable": false,
       "topic": "win7",
       "platform_build": "win64",
-      "interval_minutes": 1,
+      "interval_minutes": 10,
       "amount": 1,
       "cmd": "download-latest-nightly",
       "configs": {}
@@ -15,7 +15,7 @@
       "enable": false,
       "topic": "win10",
       "platform_build": "win64",
-      "interval_minutes": 1,
+      "interval_minutes": 10,
       "amount": 1,
       "cmd": "download-latest-nightly",
       "configs": {}
@@ -24,7 +24,7 @@
       "enable": false,
       "topic": "darwin",
       "platform_build": "mac",
-      "interval_minutes": 1,
+      "interval_minutes": 10,
       "amount": 1,
       "cmd": "download-latest-nightly",
       "configs": {}

--- a/ejenti/jobs/pulse.py
+++ b/ejenti/jobs/pulse.py
@@ -67,6 +67,13 @@ def listen_pulse(**kwargs):
     configs = kwargs.get('configs')
     username = configs.get('username')
     password = configs.get('password')
+
+    if not username or not password:
+        # there is no Pulse account information in "job_config.json"
+        logging.error('Cannot access Pulse due to there is no Pulse account information,'
+                      ' please check {} file.'.format('job_config'))
+        return
+
     topic = get_topic()
     consumer_label = topic
 

--- a/ejenti/jobs/pulse.py
+++ b/ejenti/jobs/pulse.py
@@ -1,9 +1,14 @@
 import sys
+import socket
 import pickle
 import logging
 import platform
+
+from mozillapulse.messages.base import GenericMessage
+
 # The job will be imported by ejenti. Top level will be `ejenti`, not `hasal` or `ejenti.jobs`.
 from pulse_modules.hasal_consumer import HasalConsumer  # NOQA
+from pulse_modules.hasal_publisher import HasalPublisher  # NOQA
 
 
 PULSE_KEY_TASK = 'task'
@@ -86,14 +91,22 @@ def listen_pulse(**kwargs):
         queue_type_async: async_queue
     }
 
-    # define the callback
     def got_msg(body, message):
-        # handle the message
-        # ack then broker will remove this message from queue
+        """
+        handle the message
+        ack then broker will remove this message from queue
+        """
         message.ack()
 
         data_payload = body.get('payload')
 
+        # handle response info to Trigger
+        try:
+            response_agent_info(data_payload)
+        except Exception as e:
+            logging.error(e)
+
+        # logging debug information
         debug_message = ''
         for debug_key in [key for key in data_payload.keys() if key.startswith(PULSE_KEY_DEBUG_PREFIX)]:
             debug_message += '{key}: {value}\n'.format(key=debug_key, value=data_payload.get(debug_key, ''))
@@ -101,9 +114,11 @@ def listen_pulse(**kwargs):
             logging.debug('### Pulse Got MSG ###\n{line}\n{dbg_msg}{line}'.format(dbg_msg=debug_message,
                                                                                   line='-' * 20))
 
+        # get MetaTask
         meta_task = data_payload.get(PULSE_KEY_TASK)
         meta_task_object = pickle.loads(meta_task)
 
+        # Handle command into specify queue
         task_command_key = meta_task_object.command_key
         task_queue_type = meta_task_object.queue_type
         logging.debug('Task Command Key: {}, and Queue Type: {}'.format(task_command_key, task_queue_type))
@@ -119,6 +134,59 @@ def listen_pulse(**kwargs):
         logging.debug('Push task into [{}] queue with command name {}.'.format(task_queue_type,
                                                                                task_command_key))
 
+    def response_agent_info(data_payload):
+        """
+        Return back the received MetaTask UID and agent information to Pulse "mgt" topic channel.
+        """
+        # the debug information key name
+        DEBUG_QUEUE_TYPE = 'debug_queue_type'
+        DEBUG_COMMAND_NAME = 'debug_command_name'
+        DEBUG_OVERWRITE_COMMAND_CONFIGS = 'debug_overwrite_command_configs'
+        DEBUG_UID = 'debug_UID'
+        # define mgt keys
+        PULSE_MGT_TOPIC = 'mgt'
+        PULSE_MGT_OBJECT_KEY = 'message'
+        PULSE_MGT_OBJECT_TASK_UID = 'task_uid'
+        PULSE_MGT_OBJECT_HOSTNAME = 'hostname'
+        PULSE_MGT_OBJECT_IP = 'ip'
+        PULSE_MGT_OBJECT_TOPIC = 'topic'
+        PULSE_MGT_OBJECT_PLATFORM = 'platform'
+        PULSE_MGT_OBJECT_CMD_NAME = 'cmd_name'
+        PULSE_MGT_OBJECT_CMD_CFG = 'cmd_configs'
+        PULSE_MGT_OBJECT_QUEUE_TYPE = 'queue_type'
+        # getting the agent information
+        ret_uid = data_payload.get(DEBUG_UID, '')
+        ret_hostname = socket.gethostname()
+        ret_ip = socket.gethostbyname(socket.gethostname())
+        ret_topic = get_topic()
+        ret_platform = sys.platform
+        ret_cmd_name = data_payload.get(DEBUG_COMMAND_NAME, '')
+        ret_cmd_cfg = data_payload.get(DEBUG_OVERWRITE_COMMAND_CONFIGS, '')
+        ret_queue_type = data_payload.get(DEBUG_QUEUE_TYPE, '')
+        # prepare the sending data
+        data = {
+            PULSE_MGT_OBJECT_TASK_UID: ret_uid,
+            PULSE_MGT_OBJECT_HOSTNAME: ret_hostname,
+            PULSE_MGT_OBJECT_IP: ret_ip,
+            PULSE_MGT_OBJECT_TOPIC: ret_topic,
+            PULSE_MGT_OBJECT_PLATFORM: ret_platform,
+            PULSE_MGT_OBJECT_CMD_NAME: ret_cmd_name,
+            PULSE_MGT_OBJECT_CMD_CFG: ret_cmd_cfg,
+            PULSE_MGT_OBJECT_QUEUE_TYPE: ret_queue_type
+        }
+        # make publisher
+        p = HasalPublisher(user=username, password=password)
+        # prepare message
+        mymessage = GenericMessage()
+        # setup topic
+        mymessage.routing_parts.append(PULSE_MGT_TOPIC)
+        mymessage.set_data(PULSE_MGT_OBJECT_KEY, data)
+        # send
+        p.publish(mymessage)
+        # disconnect
+        p.disconnect()
+
+    # create consumer
     c = HasalConsumer(user=username, password=password, applabel=consumer_label)
     c.configure(topic=topic, callback=got_msg)
 

--- a/ejenti/pulse_modules/tasksTrigger.py
+++ b/ejenti/pulse_modules/tasksTrigger.py
@@ -65,8 +65,16 @@ class TasksTrigger(object):
         self.pulse_username = config.get(TasksTrigger.KEY_CONFIG_PULSE_USER)
         self.pulse_password = config.get(TasksTrigger.KEY_CONFIG_PULSE_PWD)
 
+        self._validate_data()
+
         self.scheduler = BackgroundScheduler()
         self.scheduler.start()
+
+    def _validate_data(self):
+        # validate Pulse account
+        if not self.pulse_username or not self.pulse_password:
+            # there is no Pulse account information in "job_config.json"
+            raise Exception('Cannot access Pulse due to there is no Pulse account information.')
 
     @staticmethod
     def get_all_latest_files():

--- a/ejenti/pulse_modules/tasksTrigger.py
+++ b/ejenti/pulse_modules/tasksTrigger.py
@@ -1,11 +1,14 @@
 import os
 import re
 import shutil
+import socket
+import json
 import hashlib
 import logging
 import urllib2
 import urlparse
 from datetime import datetime
+from logging.handlers import TimedRotatingFileHandler
 from apscheduler.schedulers.background import BackgroundScheduler
 
 from hasal_consumer import HasalConsumer
@@ -307,7 +310,73 @@ class TasksTrigger(object):
                                          overwrite_cmd_configs=overwrite_cmd_config,
                                          uid=uid)
 
+    @staticmethod
+    def job_listen_response_from_agent(username, password, rotating_file_path):
+        """
+        [JOB]
+        Logging the message from Agent by Pulse "mgt" topic channel.
+        @param username: Pulse username.
+        @param password: Pulse password.
+        @param rotating_file_path: The rotating file path.
+        """
+        PULSE_MGT_TOPIC = 'mgt'
+        PULSE_MGT_OBJECT_KEY = 'message'
+
+        rotating_logger = logging.getLogger("RotatingLog")
+        rotating_logger.setLevel(logging.INFO)
+
+        # create Rotating File Handler, 1 day, backup 30 times.
+        rotating_handler = TimedRotatingFileHandler(rotating_file_path,
+                                                    when='d',
+                                                    interval=1,
+                                                    backupCount=30)
+
+        rotating_formatter = logging.Formatter('%(asctime)s, %(levelname)s, %(message)s')
+        rotating_handler.setFormatter(rotating_formatter)
+        rotating_logger.addHandler(rotating_handler)
+
+        def got_response(body, message):
+            """
+            handle the message
+            ack then broker will remove this message from queue
+            """
+            message.ack()
+            data_payload = body.get('payload')
+            msg_dict_obj = data_payload.get(PULSE_MGT_OBJECT_KEY)
+            try:
+                msg_str = json.dumps(msg_dict_obj)
+                rotating_logger.info(msg_str)
+            except:
+                rotating_logger.info(msg_dict_obj)
+
+        hostname = socket.gethostname()
+        consumer_label = 'TRIGGER-{hostname}'.format(hostname=hostname)
+        topic = PULSE_MGT_TOPIC
+        c = HasalConsumer(user=username, password=password, applabel=consumer_label)
+        c.configure(topic=topic, callback=got_response)
+
+        c.listen()
+
     def run(self):
+        """
+        Adding jobs into scheduler.
+        """
+        # create "mgt" channel listener
+        logging.info('Adding Rotating Logger for listen Agent information ...')
+        MGT_ID = 'trigger_mgt_listener'
+        MGT_LOG_PATH = 'rotating_mgt.log'
+        self.scheduler.add_job(func=TasksTrigger.job_listen_response_from_agent,
+                               trigger='interval',
+                               id=MGT_ID,
+                               max_instances=1,
+                               seconds=10,
+                               args=[],
+                               kwargs={'username': self.pulse_username,
+                                       'password': self.pulse_password,
+                                       'rotating_file_path': MGT_LOG_PATH})
+        logging.info('Adding Rotating Logger done: {fp}'.format(fp=os.path.abspath(MGT_LOG_PATH)))
+
+        # create each Trigger jobs
         for job_name, job_detail in self.jobs_config.items():
             """
             ex:

--- a/ejenti/pulse_trigger.py
+++ b/ejenti/pulse_trigger.py
@@ -49,6 +49,9 @@ def main():
     config_arg = arguments['--config']
     config_file = os.path.abspath(config_arg)
     config = CommonUtil.load_json_file(config_file)
+    if not config:
+        logging.error('There is not trigger config. (Loaded from {})'.format(config_file))
+        exit(1)
 
     # filter the logger
     log_filter = LogFilter()
@@ -60,13 +63,18 @@ def main():
     cmd_config_file = os.path.abspath(cmd_config_arg)
     command_config = CommonUtil.load_json_file(cmd_config_file)
     if not command_config:
-        raise Exception('There is not command config. (Loaded from {})'.format(cmd_config_file))
+        logging.error('There is not command config. (Loaded from {})'.format(cmd_config_file))
+        exit(1)
 
-    trigger = TasksTrigger(config=config, cmd_config_obj=command_config)
-    trigger.run()
+    try:
+        trigger = TasksTrigger(config=config, cmd_config_obj=command_config)
+        trigger.run()
 
-    while True:
-        time.sleep(10)
+        while True:
+            time.sleep(10)
+    except Exception as e:
+        logging.error(e)
+        exit(1)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- modify the time interval of checking in `trigger_config.json` from 1 min to 10 min.
- modify `pulse.py` to check username/pwd before listen Pulse.
- add `response_agent_info()` in `pulse.py` to response Agent info to Pulse `mgt` topic, so Trigger can get the Agent info.
- modify `tasksTrigger.py` to check username/pwd, raise Exception if there is no account info.
- add `job_listen_response_from_agent()` in `tasksTrigger.py` to listen the `mgt` topic for getting Agent info from Agents and save them into Rotating Logger.
  - `TimedRotatingFileHandler`: interval 1 day, 30 backup files will be kept.
