### PR TITLE
Modify the python packages requirments

### DIFF
--- a/ejenti/requirements.txt
+++ b/ejenti/requirements.txt
@@ -1,7 +1,9 @@
-APScheduler==3.0.3
 docopt==0.6.2
-SQLAlchemy==1.1.11
 tqdm==4.15.0
+
+APScheduler==3.3.1
+SQLAlchemy==1.1.13
+
 mozillapulse==1.3
 slackclient==1.0.6
 websocket-client==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pyperclip>=1.5.27
 web.py>=0.38
 docopt==0.6.2
 pyssim==0.3
-APScheduler==3.0.3
 argparse==1.2.1
 watchdog==0.8.3
 peakutils==1.0.3
@@ -16,11 +15,13 @@ treeherder-client==3.1.0
 selenium==3.0.2
 jsonschema==2.6.0
 geckoprofiler_controller==0.0.4
-matplotlib==1.5.3
-ipython==5.3.0
-pandas>=0.19.2
-runipy==0.1.5
 
 python-dateutil
 keyring
 requests
+
+# import ipynb related packages, remove it after we remove related imported packages from Hasal
+-r requirements_ipynb.txt
+
+# When we replace the old agent by ejenti, then we can remove following package
+APScheduler==3.3.1

--- a/requirements_devops.txt
+++ b/requirements_devops.txt
@@ -1,2 +1,2 @@
-uritemplate.py
+uritemplate.py==3.0.2
 github3.py==1.0.0a4

--- a/requirements_ipynb.txt
+++ b/requirements_ipynb.txt
@@ -1,0 +1,4 @@
+matplotlib==1.5.3
+ipython==5.3.0
+pandas>=0.19.2
+runipy==0.1.5

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,1 +1,1 @@
-appscript>=1.0.1
+appscript==1.0.1


### PR DESCRIPTION
- pin `appscript` to 1.0.1 for Mac
- pin `uritemplate.py` to 3.0.2 for devops
- update `APScheduler` and `SQLAlchemy` for ejenti
- add ejenti's requirements into general requirements
- move `matplotlib`, `ipython`, `pandas`, and `runipy` to `requirements_ipynb`
- add comments for `APScheduler` in `requirements`
  - prepare to remove `APScheduler` from requirements when we remove the old agent