### PR TITLE
Modify the python packages requirements files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,15 @@
 PYTHON := python
-VENV := ~/.hasalenv
+VENV := ./env-python-dev
 
 $(VENV)/bin/python:
 	[ -d $(VENV) ] || $(PYTHON) -m virtualenv $(VENV) || virtualenv $(VENV)
 	$(VENV)/bin/pip install --upgrade setuptools pip
+
+	# For bugzilla
 	$(VENV)/bin/pip install -U -e git+git://github.com/jbalogh/check.git#egg=check
 	$(VENV)/bin/pip install -U -e git+git://github.com/askeing/remoteobjects.git#egg=remoteobjects
 	$(VENV)/bin/pip install -U -e git+git://github.com/askeing/bztools.git#egg=bztools
+
 	$(VENV)/bin/pip install -Ur requirements.txt
 	$(VENV)/bin/python setup.py develop
 
@@ -17,7 +20,7 @@ dev-env: $(VENV)/bin/python
 
 # for testing
 .PHONY: test
-test: dev-env
+test:
 	./mach test-config
 	./mach test-tidy --no-progress --all
 
@@ -42,16 +45,16 @@ video-recording-libs-install:
 
 venv-install:
 ifndef VIRTUAL_ENV
-	virtualenv venv
+	virtualenv $(VENV)
 endif
 
 cv2-install-venv:
-	cd env/lib/python2.7/site-packages
+	cd $(VENV)/lib/python2.7/site-packages
 	ln -s /usr/local/lib/python2.7/dist-packages/cv2.so cv2.so
 	cd ../../..
 
 pip-install:
-	source venv/bin/activate
+	source $(VENV)/bin/activate
 	pip install selenium
 	pip install numpy
 

--- a/ejenti/requirements.txt
+++ b/ejenti/requirements.txt
@@ -1,7 +1,9 @@
-APScheduler==3.0.3
 docopt==0.6.2
-SQLAlchemy==1.1.11
 tqdm==4.15.0
+
+APScheduler==3.3.1
+SQLAlchemy==1.1.13
+
 mozillapulse==1.3
 slackclient==1.0.6
 websocket-client==0.40.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,6 @@ pyperclip>=1.5.27
 web.py>=0.38
 docopt==0.6.2
 pyssim==0.3
-APScheduler==3.0.3
 argparse==1.2.1
 watchdog==0.8.3
 peakutils==1.0.3
@@ -16,11 +15,13 @@ treeherder-client==3.1.0
 selenium==3.0.2
 jsonschema==2.6.0
 geckoprofiler_controller==0.0.4
-matplotlib==1.5.3
-ipython==5.3.0
-pandas>=0.19.2
-runipy==0.1.5
 
 python-dateutil
 keyring
 requests
+
+# import ipynb related packages, remove it after we remove related imported packages from Hasal
+-r requirements_ipynb.txt
+
+# When we replace the old agent by ejenti, then we can remove following package
+APScheduler==3.3.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,7 @@ treeherder-client==3.1.0
 selenium==3.0.2
 jsonschema==2.6.0
 geckoprofiler_controller==0.0.4
-
-python-dateutil
-keyring
-requests
+requests==2.18.4
 
 # When we remove related imported packages from Hasal, move following packages into other file
 matplotlib==1.5.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,10 @@
 theano==0.8.2
-numpy>=1.10.0
-psutil>=4.1.0
+numpy==1.13.1
+psutil==5.2.2
 oauth2client==3.0.0
 google-api-python-client==1.5.3
 PyDrive==1.0.1
-pyperclip>=1.5.27
-web.py>=0.38
+pyperclip==1.5.27
 docopt==0.6.2
 pyssim==0.3
 argparse==1.2.1
@@ -20,8 +19,12 @@ python-dateutil
 keyring
 requests
 
-# import ipynb related packages, remove it after we remove related imported packages from Hasal
--r requirements_ipynb.txt
+# When we remove related imported packages from Hasal, move following packages into other file
+matplotlib==1.5.3
+ipython==5.3.0
+pandas==0.19.2
+runipy==0.1.5
 
 # When we replace the old agent by ejenti, then we can remove following package
 APScheduler==3.3.1
+web.py==0.38

--- a/requirements_devops.txt
+++ b/requirements_devops.txt
@@ -1,2 +1,2 @@
-uritemplate.py
+uritemplate.py==3.0.2
 github3.py==1.0.0a4

--- a/requirements_ipynb.txt
+++ b/requirements_ipynb.txt
@@ -1,0 +1,4 @@
+matplotlib==1.5.3
+ipython==5.3.0
+pandas>=0.19.2
+runipy==0.1.5

--- a/requirements_ipynb.txt
+++ b/requirements_ipynb.txt
@@ -1,4 +1,0 @@
-matplotlib==1.5.3
-ipython==5.3.0
-pandas>=0.19.2
-runipy==0.1.5

--- a/requirements_mac.txt
+++ b/requirements_mac.txt
@@ -1,1 +1,1 @@
-appscript>=1.0.1
+appscript==1.0.1


### PR DESCRIPTION
- modify `Makefile` for speed up the `make test`
- remove `keyring` and `python-dateutil`
- pin `requests` to 2.18.4
- pin `appscript` to 1.0.1 for Mac
- pin `uritemplate.py` to 3.0.2 for devops
- update `APScheduler` and `SQLAlchemy` for ejenti
- add comments for `APScheduler` in `requirements`
  - prepare to remove `APScheduler` from requirements when we remove the old agent
  - prepare to move `matplotlib`, `ipython`, `pandas`, and `runipy` to other file

