### PR TITLE
Upload Video to different folders base on `<YEAR>-<MONTH>`

### DIFF
--- a/lib/helper/uploadResultHelper.py
+++ b/lib/helper/uploadResultHelper.py
@@ -4,6 +4,7 @@ import time
 import random
 import string
 import traceback
+from datetime import datetime
 from ..common.pyDriveUtil import PyDriveUtil
 from ..common.logConfig import get_logger
 from lib.helper.desktopHelper import get_browser_version
@@ -321,7 +322,7 @@ class PerfherderUploadDataGenerator(object):
 class VideoUploader(object):
     DEFAULT_UPLOAD_VIDEO_YAML_SETTING = "./mozhasalvideo.yaml"
     DEFAULT_UPLOAD_VIDEO_MYCRED_TXT = "./mycreds_mozhasalvideo.txt"
-    DEFAULT_UPLOAD_FOLDER_URI = "0B9g1GJPq5xo8Ry1jV0s3Y3F6ZFE"
+    DEFAULT_UPLOAD_FOLDER_URI = "0B9g1GJPq5xo8S0QwandkOGhnNUE"
 
     @staticmethod
     def upload_video(upload_video_fp):
@@ -330,8 +331,13 @@ class VideoUploader(object):
                                            "local_cred_file": VideoUploader.DEFAULT_UPLOAD_VIDEO_MYCRED_TXT})
         video_perview_url = ""
         if os.path.exists(upload_video_fp):
+            # generate folder of current month
+            upload_subfolder_name = datetime.now().strftime('%Y-%m')
+            upload_subfolder_obj = pyDriveObj.create_folder_object(VideoUploader.DEFAULT_UPLOAD_FOLDER_URI, upload_subfolder_name)
+
+            upload_folder_uri_id = upload_subfolder_obj.get('id', VideoUploader.DEFAULT_UPLOAD_FOLDER_URI)
             # upload to pydrive
-            upload_result = pyDriveObj.upload_file(VideoUploader.DEFAULT_UPLOAD_FOLDER_URI, upload_video_fp)
+            upload_result = pyDriveObj.upload_file(upload_folder_uri_id, upload_video_fp)
             if upload_result:
                 video_perview_url = "/".join(upload_result['alternateLink'].split("/")[:-1]) + "/preview"
             else:


### PR DESCRIPTION
Changing the Upload Root Folder from **test_video** to **Hasal Case Videos**.
Before uploading video file, we will check the sub-folder `<YEAR>-<MONTH>`, create sub-folder if it's not exist.
Then uploading video file into sub-folder.

This feature will help our devops work.
For example, cleaning the out-of-date video files.

Ref:
https://developers.google.com/drive/v3/web/folder
https://developers.google.com/drive/v3/web/mime-types
https://pythonhosted.org/PyDrive/filelist.html
https://pythonhosted.org/PyDrive/quickstart.html#creating-and-updating-file