### PR TITLE
	Reset `current_status` before each case run

### DIFF
--- a/lib/common/commonUtil.py
+++ b/lib/common/commonUtil.py
@@ -95,13 +95,27 @@ class StatusRecorder(object):
 
     def set_case_basic_info(self, case_name):
         current_time_stamp = datetime.strftime(datetime.now(), '%Y%m%d%H%M%S')
+        # reset case info, which contains case name and timestamp
         if self.DEFAULT_FIELD_CASE_INFO in self.current_data:
             self.current_data[self.DEFAULT_FIELD_CASE_INFO][self.DEFAULT_FIELD_CASE_NAME] = case_name
             self.current_data[self.DEFAULT_FIELD_CASE_INFO][self.DEFAULT_FIELD_CASE_TIME_STAMP] = current_time_stamp
         else:
             self.current_data[self.DEFAULT_FIELD_CASE_INFO] = {self.DEFAULT_FIELD_CASE_NAME: case_name, self.DEFAULT_FIELD_CASE_TIME_STAMP: current_time_stamp}
+        # dump to file
         with open(self.status_fp, "w+") as fh:
             json.dump(self.current_data, fh)
+        # re-load data
+        self.current_data = CommonUtil.load_json_file(self.status_fp)
+
+    def clean_legacy_status(self):
+        # reset current status
+        if self.DEFAULT_FIELD_CURRENT_STATUS in self.current_data:
+            self.current_data[self.DEFAULT_FIELD_CURRENT_STATUS] = {}
+        # dump to file
+        with open(self.status_fp, "w+") as fh:
+            json.dump(self.current_data, fh)
+        # re-load data
+        self.current_data = CommonUtil.load_json_file(self.status_fp)
 
     def get_current_sikuli_status(self):
         """

--- a/runtest.py
+++ b/runtest.py
@@ -351,6 +351,7 @@ class RunTest(object):
         while current_run < self.exec_config['max-run']:
             self.logger.info("The counter is %d and the retry counter is %d" % (current_run, current_retry))
             try:
+                objStatusRecorder.clean_legacy_status()
                 objStatusRecorder.record_case_exec_time_history(objStatusRecorder.STATUS_DESC_CASE_TOTAL_EXEC_TIME)
                 self.kill_legacy_process()
                 self.run_test(test_case_module_name, test_env)


### PR DESCRIPTION
The `loop_suite()` will call `loop_test()` for each cases, and then `loop_test()` will set the case information into `running_statistics` file.

We should reset `current_status` of each case run, so we add `clean_legacy_status()` and call it before `run_test()`.
Or previous cases' customized region will affect next case.
