### PR TITLE
Adding support of sending Slack message from other Jobs

### DIFF
--- a/ejenti/ejenti.py
+++ b/ejenti/ejenti.py
@@ -54,6 +54,9 @@ class MainRunner(object):
         self.async_queue = mananger.Queue()
         self.current_job_list = []
 
+        # Slack Sending Queue
+        self.slack_sending_queue = mananger.Queue()
+
         # init logger
         self.set_logging(self.config['log_level'], self.config['log_filter'])
 
@@ -132,6 +135,7 @@ class MainRunner(object):
                                            kwargs={
                                                'async_queue': self.async_queue,
                                                'sync_queue': self.sync_queue,
+                                               'slack_sending_queue': self.slack_sending_queue,
                                                'configs': input_job_config[job_name]['configs'],
                                                'cmd_config': self.cmd_config}
                                            )


### PR DESCRIPTION
Developer can import `generate_slack_sending_message` from `slack_bot`,
generate the message object and put into `slack_sending_queue`.

Here's a Job sample:
```python
import logging
from datetime import datetime
from slack_bot import generate_slack_sending_message

def send_slack_message(**kwargs):
    slack_sending_queue = kwargs.get('slack_sending_queue')

    logging.debug('slack_sending_queue: {}'.format(slack_sending_queue))

    if slack_sending_queue is not None:
        msg = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
        msg_obj = generate_slack_sending_message(msg)

        logging.debug('Put message into Slack Sending Queue: {}'.format(msg_obj))
        slack_sending_queue.put(msg_obj)
```