### PR TITLE
Upgrade treeherder-client from 3.1.0 to 4.0.0

### DIFF
--- a/lib/helper/uploadResultHelper.py
+++ b/lib/helper/uploadResultHelper.py
@@ -14,10 +14,10 @@ logger = get_logger(__name__)
 
 
 class PerfherderUploader(object):
-    def __init__(self, client_id, secret, os_name, platform, machine_arch, build_arch, repo='mozilla-central', protocol='http', host='local.treeherder.mozilla.org'):
+
+    def __init__(self, client_id, secret, os_name, platform, machine_arch, build_arch, server_url=None, repo='mozilla-central'):
         # Perfherder Information
-        self.potocol = protocol
-        self.host = host
+        self.server_url = server_url
         self.client_id = client_id
         self.secret = secret
         self.repo = repo
@@ -249,12 +249,14 @@ class PerfherderUploader(object):
                                             extra_info_obj=extra_info_obj)
         tjc = self.create_job_collection(j_dataset)
 
-        client = TreeherderClient(protocol=self.potocol,
-                                  host=self.host,
-                                  client_id=self.client_id,
-                                  secret=self.secret)
-        # don't post resultset, that overwrites existing data. see: https://bugzilla.mozilla.org/show_bug.cgi?id=1320694
-        # client.post_collection(self.repo, trsc)
+        if self.server_url:
+            client = TreeherderClient(server_url=self.server_url,
+                                      client_id=self.client_id,
+                                      secret=self.secret)
+        else:
+            client = TreeherderClient(client_id=self.client_id,
+                                      secret=self.secret)
+
         try:
             return_result = client.post_collection(self.repo, tjc)
         except Exception as e:

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ pyssim==0.3
 argparse==1.2.1
 watchdog==0.8.3
 peakutils==1.0.3
-treeherder-client==3.1.0
+treeherder-client==4.0.0
 selenium==3.0.2
 jsonschema==2.6.0
 geckoprofiler_controller==0.0.4

--- a/runtest.py
+++ b/runtest.py
@@ -260,15 +260,16 @@ class RunTest(object):
         else:
             self.logger.error("Can't find result json file[%s], please check the current environment!" % self.global_config['default-result-fn'])
 
+        server_url = '{protocol}://{host}'.format(protocol=self.upload_config['perfherder-protocol'],
+                                                  host=self.upload_config['perfherder-host'])
         perfherder_uploader = PerfherderUploader(self.upload_config['perfherder-client-id'],
                                                  self.upload_config['perfherder-secret'],
                                                  os_name=sys.platform,
                                                  platform=self.upload_config['perfherder-pkg-platform'],
                                                  machine_arch=self.upload_config['perfherder-pkg-platform'],
                                                  build_arch=self.upload_config['perfherder-pkg-platform'],
-                                                 repo=self.upload_config['perfherder-repo'],
-                                                 protocol=self.upload_config['perfherder-protocol'],
-                                                 host=self.upload_config['perfherder-host'])
+                                                 server_url=server_url,
+                                                 repo=self.upload_config['perfherder-repo'])
 
         upload_success_timestamp_list = []
         for current_time_stamp in upload_result_data:

--- a/server/server.py
+++ b/server/server.py
@@ -618,15 +618,17 @@ class HasalServer:
                                     }
                                     # Upload to Perfherder
                                     try:
+                                        server_url = '{protocol}://{host}'.format(protocol=HasalServer._config_perfherder_protocol,
+                                                                                  host=HasalServer._config_perfherder_host)
+
                                         uploader = PerfherderUploader(HasalServer._config_perfherder_client_id,
                                                                       HasalServer._config_perfherder_secret,
                                                                       os_name=os_name,
                                                                       platform=test_result.get('platform'),
                                                                       machine_arch=test_result.get('platform'),
                                                                       build_arch=test_result.get('platform'),
-                                                                      repo=HasalServer._config_perfherder_repo,
-                                                                      protocol=HasalServer._config_perfherder_protocol,
-                                                                      host=HasalServer._config_perfherder_host)
+                                                                      server_url=server_url,
+                                                                      repo=HasalServer._config_perfherder_repo)
                                         uploader.submit(revision=test_result.get('revision'),
                                                         browser=browser_name,
                                                         timestamp=start_timestamp,

--- a/tools/get_build.py
+++ b/tools/get_build.py
@@ -33,19 +33,19 @@ class GetBuild(object):
         self.repo = repo
         self.platform = platform
         self.platform_option = 'opt'
-        self.resultsets = []
+        self.pushes = []
         self.skip_status_check = status_check
         self.thclient = TreeherderClient()
 
-    def fetch_resultset(self, user_email, build_hash, default_count=500):
-        tmp_resultsets = self.thclient.get_resultsets(self.repo, count=default_count)
-        for resultset in tmp_resultsets:
-            if resultset['author'].lower() == user_email.lower():
-                self.resultsets.append(resultset)
+    def fetch_push(self, user_email, build_hash, default_count=500):
+        tmp_pushes = self.thclient.get_pushes(self.repo, count=default_count)
+        for push in tmp_pushes:
+            if push['author'].lower() == user_email.lower():
+                self.pushes.append(push)
                 if build_hash is None:
-                    return resultset
-                elif resultset['revision'] == build_hash:
-                    return resultset
+                    return push
+                elif push['revision'] == build_hash:
+                    return push
         print "Can't find the specify build hash [%s] in resultsets!!" % build_hash
         return None
 
@@ -147,7 +147,7 @@ class GetBuild(object):
             return False
 
     def get_try_build(self, user_email, build_hash, output_dp):
-        resultset = self.fetch_resultset(user_email, build_hash)
+        resultset = self.fetch_push(user_email, build_hash)
 
         # check result set
         if resultset:

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-treeherder-client==3.1.0
+treeherder-client==4.0.0
 docopt==0.6.2
 tqdm==4.15.0
 python-dateutil==2.6.1

--- a/tools/trigger_build.py
+++ b/tools/trigger_build.py
@@ -48,7 +48,7 @@ class TriggerBuild(object):
     def __init__(self, input_env_data):
         self.platform_option = 'opt'
         self.thclient = TreeherderClient()
-        self.resultsets = []
+        self.pushes = []
         self.env_data = {key.upper(): value for key, value in input_env_data.items()}
         self.dispatch_variables(self.env_data)
 
@@ -198,15 +198,15 @@ class TriggerBuild(object):
                 print "ERROR: hasal json file in not in new location [%s]" % new_hasal_json_fp
             sys.exit(0)
 
-    def fetch_resultset(self, user_email, build_hash, default_count=500):
-        tmp_resultsets = self.thclient.get_resultsets(self.repo, count=default_count)
-        for resultset in tmp_resultsets:
-            if resultset['author'].lower() == user_email.lower():
-                self.resultsets.append(resultset)
+    def fetch_push(self, user_email, build_hash, default_count=500):
+        tmp_pushes = self.thclient.get_pushes(self.repo, count=default_count)
+        for push in tmp_pushes:
+            if push['author'].lower() == user_email.lower():
+                self.pushes.append(push)
                 if build_hash is None:
-                    return resultset
-                elif resultset['revision'] == build_hash:
-                    return resultset
+                    return push
+                elif push['revision'] == build_hash:
+                    return push
         print "Can't find the specify build hash [%s] in resultsets!!" % build_hash
         return None
 
@@ -309,7 +309,7 @@ class TriggerBuild(object):
             return None
 
     def get_try_build(self, user_email, build_hash, output_dp):
-        resultset = self.fetch_resultset(user_email, build_hash)
+        resultset = self.fetch_push(user_email, build_hash)
 
         # check result set
         if resultset:


### PR DESCRIPTION
Changes from https://bugzilla.mozilla.org/show_bug.cgi?id=1387711#c2

- [x] Removal of `TreeherderArtifact`, `TreeherderArtifactCollection`
  and `get_artifacts()` since the REST API no longer supports
  submitting artifacts independently of the job data submission.

  * We couldn’t find any code matching `TreeherderArtifact`
  * We couldn’t find any code matching `TreeherderArtifactCollection`
  * We couldn’t find any code matching `get_artifacts`

- [x] Removal of `TreeherderRevision`, `TreeherderResultSet` and
  `TreeherderResultSetCollection` since pushes can now only be
  submitted via Pulse.

  * We couldn’t find any code matching `TreeherderRevision`
  * We couldn’t find any code matching `TreeherderResultSet`
  * For `TreeherderResultSetCollection`
    * Remove `create_resultset_collection()` from `server/perfherder_uploader.py`

- [x] Removal of the previously deprecated `add_revision_hash()` since
  revision hashes are no longer required, and instead the revision
  should be added to a job directly, using `add_revision()`.

  * We couldn’t find any code matching `add_revision_hash`

- [x] Removal of the previously deprecated `protocol` and `host` parameters
  to `TreeherderClient`. Use the `server_url` parameter instead.
  * Modify `lib/helper/uploadResultHelper.py` and `server/perfherder_uploader.py`
  Ref: https://github.com/mozilla/treeherder/commit/6ea5b43386443978def45cd6f7bafc6a36f60a96

- [x] Deprecation of `TreeherderClient`'s `get_resultsets()` in favour of
  `get_pushes()`. They also now send requests to the `/push/` API
  endpoint rather than `/resultset/` (identical other than the name).

  * For `get_resultsets()`
	* Modify `get_resultsets()` to `get_pushes()` from `tools/get_build.py` and `tools/trigger_build.py`
	Ref: https://github.com/mozilla/treeherder/commit/c6e0c26bc8f0adc1490de7c7f130d35ab892e3be

