### PR TITLE
Adding support for listing all agents on Slack

### DIFF
--- a/ejenti/jobs/pulse.py
+++ b/ejenti/jobs/pulse.py
@@ -8,9 +8,9 @@ from mozillapulse.messages.base import GenericMessage
 
 # The job will be imported by ejenti. Top level will be `ejenti`, not `hasal` or `ejenti.jobs`.
 try:
-    from ..pulse_modules.hasal_consumer import HasalConsumer  # NOQA
-    from ..pulse_modules.hasal_publisher import HasalPublisher  # NOQA
-    from ..pulse_modules.hasalPulsePublisher import HasalPulsePublisher  # NOQA
+    from ejenti.pulse_modules.hasal_consumer import HasalConsumer  # NOQA
+    from ejenti.pulse_modules.hasal_publisher import HasalPublisher  # NOQA
+    from ejenti.pulse_modules.hasalPulsePublisher import HasalPulsePublisher  # NOQA
 except:
     from pulse_modules.hasal_consumer import HasalConsumer  # NOQA
     from pulse_modules.hasal_publisher import HasalPublisher  # NOQA

--- a/ejenti/jobs/slack_bot.py
+++ b/ejenti/jobs/slack_bot.py
@@ -691,7 +691,7 @@ def handle_rtm_message_leader_help(slack_client, rtm_ret, configs, cmd_config, e
 
 
 def handle_rtm_message_leader_list_agents(slack_client, rtm_ret, configs, cmd_config, election_type, bot_user_obj,
-                                   bot_mgt_channel_obj, follower_list, leader_cmd_list):
+                                          bot_mgt_channel_obj, follower_list, leader_cmd_list):
     """
     Leader will handle the RTM help message, show usage.
     Will be register in LEADER_CMD_HANDLERS.
@@ -714,8 +714,8 @@ def handle_rtm_message_leader_list_agents(slack_client, rtm_ret, configs, cmd_co
 
     msg = '*[Current Agents]*\n'
     msg += '{hn}/{ip}, PID {pid}, Leader\n'.format(hn=get_current_hostname(),
-                                                    ip=get_current_ip(),
-                                                    pid=os.getpid())
+                                                   ip=get_current_ip(),
+                                                   pid=os.getpid())
 
     for agent_key, agent_object in sorted(follower_list.items()):
 
@@ -723,12 +723,16 @@ def handle_rtm_message_leader_list_agents(slack_client, rtm_ret, configs, cmd_co
         ip_addr = agent_object.get(KEY_FOLLOWER_INFO_IP, 'NA')
         pid = agent_object.get(KEY_FOLLOWER_INFO_PID, 'NA')
         ts = agent_object.get(KEY_FOLLOWER_INFO_TIMESTAMP, 0)
-        sec = '{}s ago'.format(int(current_time - ts)) if ts else 'unknow'
+
+        if current_time > ts:
+            sec = '{}s ago'.format(int(current_time - ts)) if ts else 'unknow'
+        else:
+            sec = 'pls update NTP'
 
         msg += '{hn}/{ip}, PID {pid}, {sec}\n'.format(hn=hn,
-                                                        ip=ip_addr,
-                                                        pid=pid,
-                                                        sec=sec)
+                                                      ip=ip_addr,
+                                                      pid=pid,
+                                                      sec=sec)
 
     send(slack_client, msg, bot_mgt_channel_obj)
 

--- a/ejenti/jobs/slack_bot.py
+++ b/ejenti/jobs/slack_bot.py
@@ -656,12 +656,7 @@ def handle_rtm_message_leader_help(slack_client, rtm_ret, configs, cmd_config, e
         if cmd_obj.get('queue-type') == 'async':
             async_commands[cmd_key] = cmd_obj.get('desc', '')
 
-    help_message = '*[Usage]*\n\n' \
-                   '*Input Format* <Agent> <Command> [<Configs>]\n' \
-                   '    <Agent>: string, hostname or ip address.\n' \
-                   '    <Command>: string, command name.\n' \
-                   '    <Configs>: JSON, configs.\n\n' \
-                   'Here is supported commands.\n\n'
+    help_message = 'Here is supported commands.\n\n'
 
     # Leader commands
     help_message += '*[Leader Commands]*\n'
@@ -685,6 +680,12 @@ def handle_rtm_message_leader_help(slack_client, rtm_ret, configs, cmd_config, e
         help_message += '*Sync Commands*\n'
         for cmd_name in sorted(async_commands):
             help_message += '    *{cmd}*\t{desc}\n'.format(cmd=cmd_name, desc=async_commands.get(cmd_name))
+
+    help_message += '\n*[Usage]*\n' \
+                    '*Input Format* <Agent> <Command> [<Configs>]\n' \
+                    '    <Agent>: string, hostname or ip address.\n' \
+                    '    <Command>: string, command name.\n' \
+                    '    <Configs>: JSON, configs.\n\n' \
 
     send(slack_client, help_message, bot_mgt_channel_obj)
 

--- a/ejenti/slack_modules/interactive_commands.py
+++ b/ejenti/slack_modules/interactive_commands.py
@@ -15,7 +15,6 @@ def cmd_disk_usage(sending_queue, cmd_configs={}):
 
     msg_obj = _generate_slack_sending_message(msg)
     sending_queue.put(msg_obj)
-    pass
 
 
 def _generate_slack_sending_message(message, channel='mgt'):


### PR DESCRIPTION
Now, user can type `help` and `list-agents` in slack mgt channel.