### PR TITLE
Adding clean_pulse_queues feature for pulse_trigger with `--clean`

### DIFF
--- a/ejenti/pulse_modules/hasalPulsePublisher.py
+++ b/ejenti/pulse_modules/hasalPulsePublisher.py
@@ -82,7 +82,7 @@ class HasalPulsePublisher(object):
                 return False
         queue_exists = c.queue_exists()
         logging.debug('Pulse Queue on Topic [{}] exists ... {}'.format(topic, queue_exists))
-        return True
+        return queue_exists
 
     @staticmethod
     def re_create_pulse_queue(username, password, topic):

--- a/ejenti/pulse_trigger.py
+++ b/ejenti/pulse_trigger.py
@@ -2,13 +2,14 @@
 # -*- encoding: utf-8 -*-
 """
 Usage:
-  pulse_trigger.py [--config=<str>] [--cmd-config=<str>]
+  pulse_trigger.py [--config=<str>] [--cmd-config=<str>] [--clean]
   pulse_trigger.py (-h | --help)
 
 Options:
   -h --help                       Show this screen.
   --config=<str>                  Specify the trigger_config.json file path. [default: configs/ejenti/trigger_config.json]
   --cmd-config=<str>              Specify the cmd_config.json file path. [default: configs/ejenti/cmd_config.json]
+  --clean                         Clean Pulse Queue on Pulse service. [default: False]
 """
 
 import os
@@ -68,8 +69,9 @@ def main():
         logging.error('There is not command config. (Loaded from {})'.format(cmd_config_file))
         exit(1)
 
+    clean_flag = arguments['--clean']
     try:
-        trigger = TasksTrigger(config=config, cmd_config_obj=command_config)
+        trigger = TasksTrigger(config=config, cmd_config_obj=command_config, clean_at_begin=clean_flag)
         trigger.run()
 
         while True:


### PR DESCRIPTION
Re-create the Pulse queue for cleaning Dead Consumer Client on Pulse.
Dead Consumer Client will get messages without ack(), so messages will always stay on Pulse, and no one can handle it.