### PR TITLE
disable DRM notification

### DIFF
--- a/configs/firefox/default.json
+++ b/configs/firefox/default.json
@@ -35,7 +35,8 @@
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,
-    "layout.css.servo.enabled": true
+    "layout.css.servo.enabled": true,
+    "browser.eme.ui.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/geckoprofiler.json
+++ b/configs/firefox/geckoprofiler.json
@@ -35,7 +35,8 @@
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,
-    "layout.css.servo.enabled": true
+    "layout.css.servo.enabled": true,
+    "browser.eme.ui.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/har.json
+++ b/configs/firefox/har.json
@@ -39,7 +39,8 @@
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,
-    "layout.css.servo.enabled": true
+    "layout.css.servo.enabled": true,
+    "browser.eme.ui.enabled": false
   },
   "cookies": {
     "folder": "0BwkEhia_D6l_bVJ0aDdGSU5pMzg",

--- a/configs/firefox/obs_on_windows.json
+++ b/configs/firefox/obs_on_windows.json
@@ -35,7 +35,8 @@
     "browser.onboarding.enabled": false,
     "browser.onboarding.hidden": true,
     "browser.onboarding.notification.finished": true,
-    "layout.css.servo.enabled": true
+    "layout.css.servo.enabled": true,
+    "browser.eme.ui.enabled": false
   },
   "profile_files": {
     "DisableStatusBar": {

--- a/tests/regression/amazon/test_firefox_amazon_ail_hover_related_product_thumbnail.sikuli/test_firefox_amazon_ail_hover_related_product_thumbnail.py
+++ b/tests/regression/amazon/test_firefox_amazon_ail_hover_related_product_thumbnail.sikuli/test_firefox_amazon_ail_hover_related_product_thumbnail.py
@@ -42,6 +42,7 @@ class Case(basecase.SikuliInputLatencyCase):
 
         # PRE ACTIONS
         type(Key.PAGE_DOWN)
+        type(Key.UP)
         sleep(2)
 
         # Customized Region


### PR DESCRIPTION
We encountered an issue that a notification UI on top of Firefox browser is showing and blocking us from detecting the targeted waiting element. Even if I disable DRM using `media.eme.enabled=false`, it would still show me an message for asking me to reactivate DRM.

In that case, I made `browser.eme.ui.enabled=false`, and this should disable any further message from Firefox about DRM media related information.

@ShakoHo @askeing r?

