### PR TITLE
Adding ejenti and tools into epydoc.cfg

### DIFF
--- a/python/epydoc.cfg
+++ b/python/epydoc.cfg
@@ -9,7 +9,7 @@ url: https://github.com/Mozilla-TWQA/Hasal
 # The list of modules to document.  Modules can be named using
 # dotted names, module filenames, or package directory names.
 # This option may be repeated.
-modules: agent, lib, server
+modules: agent, ejenti, lib, server, tools
 
 # Write html output to the directory "apidocs"
 output: html


### PR DESCRIPTION
will add `ejenti` and `tools` into http://mozilla-twqa.github.io/Hasal/api/