### PR TITLE
Fill the value list when there is no case result when generating the dashboard data

### DIFF
--- a/unit/ejenti/server_jobs/test_dashboard_data_genetator.py
+++ b/unit/ejenti/server_jobs/test_dashboard_data_genetator.py
@@ -66,49 +66,90 @@ class TestTasksTriggerMethods(unittest.TestCase):
 
         expected_ret = [
             {
-                'timestamp': '1510091849',
-                'timestamp_js': 1510091849000,
-                'casename': 'foo_ail_type_in_search_field',
-                'browser': 'chrome',
-                'platform': 'windows10-64',
-                'value_list': [5.56, 5.56],
-                'revision': 'rev_1510091849',
-                'signature': 'sig_foo_chrome_win10'
+                "timestamp": "1510091849",
+                "timestamp_js": 1510091849000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "chrome",
+                "platform": "windows10-64",
+                "value_list": [5.56, 5.56],
+                "revision": "rev_1510091849",
+                "signature": "sig_foo_chrome_win10"
             },
             {
-                'timestamp': '1510091849',
-                'timestamp_js': 1510091849000,
-                'casename': 'foo_ail_type_in_search_field',
-                'browser': 'firefox',
-                'platform': 'windows10-64',
-                'value_list': [5.56, ],
-                'revision': 'rev_1510091849',
-                'signature': 'sig_foo_firefox_win10'
+                "timestamp": "1510091849",
+                "timestamp_js": 1510091849000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "firefox",
+                "platform": "windows10-64",
+                "value_list": [5.56],
+                "revision": "rev_1510091849",
+                "signature": "sig_foo_firefox_win10"
             },
             {
-                'timestamp': '1510138316',
-                'timestamp_js': 1510138316000,
-                'casename': 'foo_ail_type_in_search_field',
-                'browser': 'chrome',
-                'platform': 'windows10-64',
-                'value_list': [5.56, ],
-                'revision': 'rev_1510138316',
-                'signature': 'sig_foo_chrome_win10'
+                "timestamp": "1510138316",
+                "timestamp_js": 1510138316000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "chrome",
+                "platform": "windows10-64",
+                "value_list": [5.56],
+                "revision": "rev_1510138316",
+                "signature": "sig_foo_chrome_win10"
             },
             {
-                'timestamp': '1510138316',
-                'timestamp_js': 1510138316000,
-                'casename': 'foo_ail_type_in_search_field',
-                'browser': 'firefox',
-                'platform': 'windows10-64',
-                'value_list': [11.11, 5.56, 22.22],
-                'revision': 'rev_1510138316',
-                'signature': 'sig_foo_firefox_win10'
+                "timestamp": "1510138316",
+                "timestamp_js": 1510138316000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "firefox",
+                "platform": "windows10-64",
+                "value_list": [11.11, 5.56, 22.22],
+                "revision": "rev_1510138316",
+                "signature": "sig_foo_firefox_win10"
+            },
+            {
+                "timestamp": "1510091849",
+                "timestamp_js": 1510091849000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "firefox",
+                "platform": "windows8-64",
+                "value_list": [],
+                "revision": "rev_1510091849",
+                "signature": ""
+            },
+            {
+                "timestamp": "1510091849",
+                "timestamp_js": 1510091849000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "chrome",
+                "platform": "windows8-64",
+                "value_list": [],
+                "revision": "rev_1510091849",
+                "signature": ""
+            },
+            {
+                "timestamp": "1510138316",
+                "timestamp_js": 1510138316000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "firefox",
+                "platform": "windows8-64",
+                "value_list": [],
+                "revision": "rev_1510138316",
+                "signature": ""
+            },
+            {
+                "timestamp": "1510138316",
+                "timestamp_js": 1510138316000,
+                "casename": "foo_ail_type_in_search_field",
+                "browser": "chrome",
+                "platform": "windows8-64",
+                "value_list": [],
+                "revision": "rev_1510138316",
+                "signature": "",
             }
         ]
 
         app = DashboardDataGenerator()
         ret_list = app._generate_source_data()
+
         self.assertEqual(expected_ret, ret_list)
 
     @patch('lib.helper.generateBackfillTableHelper.GenerateBackfillTableHelper.get_history_archive_perfherder_relational_table')


### PR DESCRIPTION
When there is no result on Perfherder, the `backfill_table` will have no record in `perfherder_data`.

For exampe, when we have three cases **foo_case**, **bar_case**, and **latest_case**.
And the **bar_case** has no result:
```json
"perfherder_data": {
      "foo_case:firefox:windows8-64": {
        "value": [
          33.33,
          22.22
        ],
        "signature": "foo_sig"
      },
      "latest_case:firefox:windows8-64": {
        "value": [
          44.44
        ],
        "signature": "latest_sig"
      }
}
```

That's the reason why we have to check all keys, and then fill no result keys into `self.source_data`.
